### PR TITLE
fix(auth): AuthGuard is global by default, properly set optional

### DIFF
--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Get } from '@nestjs/common'
 
-import { AppService } from './app.service'
+import { AppService } from '@src/app.service'
+import { AllowAnonymous } from '@src/auth/decorators'
 
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
+  @AllowAnonymous()
   getHello(): string {
     return this.appService.getHello()
   }

--- a/apps/api/src/changes/change.resolver.ts
+++ b/apps/api/src/changes/change.resolver.ts
@@ -1,13 +1,8 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
 import { OptionalAuth } from '@src/auth/decorators'
-import { NotFoundErr } from '@src/common/exceptions'
-import { TransformService } from '@src/common/transform'
-import { User } from '@src/users/users.model'
-
-import { CreateChangeInput } from './change-ext.model'
+import { CreateChangeInput } from '@src/changes/change-ext.model'
 import {
   Change,
   ChangeEditsArgs,
@@ -23,10 +18,13 @@ import {
   MergeChangeOutput,
   UpdateChangeInput,
   UpdateChangeOutput,
-} from './change.model'
-import { ChangeService } from './change.service'
-import { EditService } from './edit.service'
-import { Source, SourcesPage } from './source.model'
+} from '@src/changes/change.model'
+import { ChangeService } from '@src/changes/change.service'
+import { EditService } from '@src/changes/edit.service'
+import { Source, SourcesPage } from '@src/changes/source.model'
+import { NotFoundErr } from '@src/common/exceptions'
+import { TransformService } from '@src/common/transform'
+import { User } from '@src/users/users.model'
 
 @Resolver(() => Change)
 export class ChangeResolver {
@@ -37,7 +35,6 @@ export class ChangeResolver {
   ) {}
 
   @Query(() => ChangesPage)
-  @UseGuards(AuthGuard)
   @OptionalAuth()
   async changes(@Args() args: ChangesArgs) {
     const [parsedArgs, filter] = await this.transform.paginationArgs(ChangesArgs, args)
@@ -46,7 +43,6 @@ export class ChangeResolver {
   }
 
   @Query(() => Change, { name: 'change', nullable: true })
-  @UseGuards(AuthGuard)
   @OptionalAuth()
   async change(@Args('id', { type: () => ID }) id: string) {
     const change = await this.changeService.findOne(id)
@@ -57,7 +53,6 @@ export class ChangeResolver {
   }
 
   @Query(() => DirectEdit, { nullable: true })
-  @UseGuards(AuthGuard)
   async directEdit(@Args() args: DirectEditArgs) {
     const directEdit = await this.changeService.directEdit(args.id, args.entityName)
     if (!directEdit) {
@@ -67,7 +62,6 @@ export class ChangeResolver {
   }
 
   @Mutation(() => CreateChangeOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async createChange(
     @Args('input') input: CreateChangeInput,
     @AuthUser() user: ReqUser,
@@ -80,7 +74,6 @@ export class ChangeResolver {
   }
 
   @Mutation(() => UpdateChangeOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async updateChange(@Args('input') input: UpdateChangeInput): Promise<UpdateChangeOutput> {
     const change = await this.changeService.update(input)
     const model = await this.transform.entityToModel(Change, change)
@@ -90,7 +83,6 @@ export class ChangeResolver {
   }
 
   @Mutation(() => DeleteChangeOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async deleteChange(@Args('id', { type: () => ID }) id: string): Promise<DeleteChangeOutput> {
     await this.changeService.remove(id)
     return {
@@ -99,7 +91,6 @@ export class ChangeResolver {
   }
 
   @Mutation(() => MergeChangeOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async mergeChange(@Args('id', { type: () => ID }) id: string): Promise<MergeChangeOutput> {
     const result = await this.editService.mergeID(id)
     if (!result) {
@@ -112,7 +103,6 @@ export class ChangeResolver {
   }
 
   @Mutation(() => DiscardEditOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async discardEdit(
     @Args('changeID', { type: () => ID }) changeID: string,
     @Args('editID', { type: () => ID }) editID: string,

--- a/apps/api/src/geo/place.resolver.ts
+++ b/apps/api/src/geo/place.resolver.ts
@@ -1,12 +1,12 @@
 import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
+import { OptionalAuth } from '@src/auth/decorators'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
+import { Place, PlacesArgs, PlacesPage } from '@src/geo/place.model'
+import { PlaceService } from '@src/geo/place.service'
 import { Tag } from '@src/process/tag.model'
 import { Org } from '@src/users/org.model'
-
-import { Place, PlacesArgs, PlacesPage } from './place.model'
-import { PlaceService } from './place.service'
 
 @Resolver(() => Place)
 export class PlaceResolver {
@@ -16,6 +16,7 @@ export class PlaceResolver {
   ) {}
 
   @Query(() => PlacesPage, { name: 'places' })
+  @OptionalAuth()
   async places(@Args() args: PlacesArgs): Promise<PlacesPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(PlacesArgs, args)
     const cursor = await this.placeService.find(filter)
@@ -23,6 +24,7 @@ export class PlaceResolver {
   }
 
   @Query(() => Place, { name: 'place', nullable: true })
+  @OptionalAuth()
   async place(@Args('id', { type: () => ID }) id: string): Promise<Place> {
     const place = await this.placeService.findOneByID(id)
     if (!place) {

--- a/apps/api/src/geo/region.resolver.ts
+++ b/apps/api/src/geo/region.resolver.ts
@@ -1,10 +1,10 @@
 import { Args, ID, Query, Resolver } from '@nestjs/graphql'
 
+import { OptionalAuth } from '@src/auth/decorators'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
-
-import { Region, RegionsArgs, RegionsPage, RegionsSearchByPointArgs } from './region.model'
-import { RegionService } from './region.service'
+import { Region, RegionsArgs, RegionsPage, RegionsSearchByPointArgs } from '@src/geo/region.model'
+import { RegionService } from '@src/geo/region.service'
 
 @Resolver(() => Region)
 export class RegionResolver {
@@ -14,6 +14,7 @@ export class RegionResolver {
   ) {}
 
   @Query(() => RegionsPage, { name: 'regions' })
+  @OptionalAuth()
   async regions(@Args() args: RegionsArgs): Promise<RegionsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(RegionsArgs, args)
     const cursor = await this.regionService.find(filter)
@@ -21,6 +22,7 @@ export class RegionResolver {
   }
 
   @Query(() => Region, { name: 'region', nullable: true })
+  @OptionalAuth()
   async region(@Args('id', { type: () => ID }) id: string) {
     const region = await this.regionService.findOneByID(id)
     if (!region) {
@@ -30,6 +32,7 @@ export class RegionResolver {
   }
 
   @Query(() => RegionsPage, { name: 'searchRegionsByPoint' })
+  @OptionalAuth()
   async searchRegionsByPoint(@Args() args: RegionsSearchByPointArgs): Promise<RegionsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(RegionsSearchByPointArgs, args)
     const cursor = await this.regionService.searchByPoint(

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common'
 import { HealthCheck, HealthCheckService, MikroOrmHealthIndicator } from '@nestjs/terminus'
 
+import { AllowAnonymous } from '@src/auth/decorators'
+
 @Controller('health')
 export class HealthController {
   constructor(
@@ -10,6 +12,7 @@ export class HealthController {
 
   @Get()
   @HealthCheck()
+  @AllowAnonymous()
   check() {
     return this.health.check([() => this.db.pingCheck('database')])
   }

--- a/apps/api/src/process/component.resolver.ts
+++ b/apps/api/src/process/component.resolver.ts
@@ -1,14 +1,13 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { ZService } from '@src/common/z.service'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
-
 import {
   Component,
   ComponentRecycleArgs,
@@ -17,11 +16,11 @@ import {
   CreateComponentOutput,
   UpdateComponentInput,
   UpdateComponentOutput,
-} from './component.model'
-import { ComponentSchemaService } from './component.schema'
-import { ComponentService } from './component.service'
-import { ComponentsArgs, Material } from './material.model'
-import { Tag } from './tag.model'
+} from '@src/process/component.model'
+import { ComponentSchemaService } from '@src/process/component.schema'
+import { ComponentService } from '@src/process/component.service'
+import { ComponentsArgs, Material } from '@src/process/material.model'
+import { Tag } from '@src/process/tag.model'
 
 @Resolver(() => Component)
 export class ComponentResolver {
@@ -33,6 +32,7 @@ export class ComponentResolver {
   ) {}
 
   @Query(() => ComponentsPage, { name: 'components' })
+  @OptionalAuth()
   async components(@Args() args: ComponentsArgs): Promise<ComponentsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(ComponentsArgs, args)
     const cursor = await this.componentService.find(filter)
@@ -40,6 +40,7 @@ export class ComponentResolver {
   }
 
   @Query(() => Component, { name: 'component', nullable: true })
+  @OptionalAuth()
   async component(
     @Args('id', { type: () => ID }) id: string,
     @Args('withChange', { type: () => ID, nullable: true })
@@ -53,6 +54,7 @@ export class ComponentResolver {
   }
 
   @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
   async componentSchema(): Promise<ModelEditSchema> {
     return {
       create: {
@@ -109,7 +111,6 @@ export class ComponentResolver {
     name: 'createComponent',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async createComponent(
     @Args('input') input: CreateComponentInput,
     @AuthUser() user: ReqUser,
@@ -128,7 +129,6 @@ export class ComponentResolver {
     name: 'updateComponent',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async updateComponent(
     @Args('input') input: UpdateComponentInput,
     @AuthUser() user: ReqUser,
@@ -143,7 +143,6 @@ export class ComponentResolver {
   }
 
   @Mutation(() => DeleteOutput, { name: 'deleteComponent', nullable: true })
-  @UseGuards(AuthGuard)
   async deleteComponent(@Args('input') input: DeleteInput): Promise<DeleteOutput> {
     const component = await this.componentService.delete(input)
     return { success: true, id: component.id }

--- a/apps/api/src/process/material.resolver.ts
+++ b/apps/api/src/process/material.resolver.ts
@@ -1,5 +1,6 @@
 import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
+import { OptionalAuth } from '@src/auth/decorators'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 
@@ -23,6 +24,7 @@ export class MaterialResolver {
   ) {}
 
   @Query(() => MaterialsPage, { name: 'materials' })
+  @OptionalAuth()
   async materials(@Args() args: MaterialsArgs): Promise<MaterialsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(MaterialsArgs, args)
     const cursor = await this.materialService.find(filter)
@@ -30,6 +32,7 @@ export class MaterialResolver {
   }
 
   @Query(() => Material, { name: 'material', nullable: true })
+  @OptionalAuth()
   async material(@Args('id', { type: () => ID }) id: string): Promise<Material> {
     const material = await this.materialService.findOneByID(id)
     if (!material) {
@@ -40,6 +43,7 @@ export class MaterialResolver {
   }
 
   @Query(() => Material, { name: 'materialRoot' })
+  @OptionalAuth()
   async materialRoot(): Promise<Material> {
     const material = await this.materialService.findRoot()
     if (!material) {

--- a/apps/api/src/process/process.resolver.ts
+++ b/apps/api/src/process/process.resolver.ts
@@ -1,14 +1,13 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { ZService } from '@src/common/z.service'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
-
 import {
   CreateProcessInput,
   CreateProcessOutput,
@@ -17,9 +16,9 @@ import {
   ProcessPage,
   UpdateProcessInput,
   UpdateProcessOutput,
-} from './process.model'
-import { ProcessSchemaService } from './process.schema'
-import { ProcessService } from './process.service'
+} from '@src/process/process.model'
+import { ProcessSchemaService } from '@src/process/process.schema'
+import { ProcessService } from '@src/process/process.service'
 
 @Resolver(() => Process)
 export class ProcessResolver {
@@ -31,6 +30,7 @@ export class ProcessResolver {
   ) {}
 
   @Query(() => ProcessPage, { name: 'processes' })
+  @OptionalAuth()
   async processes(@Args() args: ProcessArgs): Promise<ProcessPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(ProcessArgs, args)
     const cursor = await this.processService.find(filter)
@@ -38,6 +38,7 @@ export class ProcessResolver {
   }
 
   @Query(() => Process, { name: 'process', nullable: true })
+  @OptionalAuth()
   async process(@Args('id', { type: () => ID }) id: string): Promise<Process> {
     const process = await this.processService.findOneByID(id)
     if (!process) {
@@ -47,6 +48,7 @@ export class ProcessResolver {
   }
 
   @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
   async processSchema(): Promise<ModelEditSchema> {
     return {
       create: {
@@ -64,7 +66,6 @@ export class ProcessResolver {
     name: 'createProcess',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async createProcess(
     @Args('input') input: CreateProcessInput,
     @AuthUser() user: ReqUser,
@@ -83,7 +84,6 @@ export class ProcessResolver {
     name: 'updateProcess',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async updateProcess(
     @Args('input') input: UpdateProcessInput,
     @AuthUser() user: ReqUser,
@@ -98,7 +98,6 @@ export class ProcessResolver {
   }
 
   @Mutation(() => DeleteOutput, { name: 'deleteProcess', nullable: true })
-  @UseGuards(AuthGuard)
   async deleteProcess(@Args('input') input: DeleteInput): Promise<DeleteOutput> {
     const process = await this.processService.delete(input)
     return { success: true, id: process.id }

--- a/apps/api/src/process/tag.resolver.ts
+++ b/apps/api/src/process/tag.resolver.ts
@@ -1,11 +1,9 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Query, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { ZService } from '@src/common/z.service'
-
 import {
   CreateTagDefinitionInput,
   CreateTagDefinitionOutput,
@@ -14,8 +12,8 @@ import {
   TagPage,
   UpdateTagDefinitionInput,
   UpdateTagDefinitionOutput,
-} from './tag.model'
-import { TagService } from './tag.service'
+} from '@src/process/tag.model'
+import { TagService } from '@src/process/tag.service'
 
 @Resolver(() => Tag)
 export class TagResolver {
@@ -26,6 +24,7 @@ export class TagResolver {
   ) {}
 
   @Query(() => TagPage, { name: 'tags' })
+  @OptionalAuth()
   async tags(@Args() args: TagArgs): Promise<TagPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(TagArgs, args)
     const cursor = await this.tagService.find(filter)
@@ -33,6 +32,7 @@ export class TagResolver {
   }
 
   @Query(() => Tag, { name: 'tag', nullable: true })
+  @OptionalAuth()
   async tag(@Args('id', { type: () => ID }) id: string): Promise<Tag> {
     const tag = await this.tagService.findOneByID(id)
     if (!tag) {
@@ -45,7 +45,6 @@ export class TagResolver {
     name: 'createTagDefinition',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async createTagDefinition(
     @Args('input') input: CreateTagDefinitionInput,
   ): Promise<CreateTagDefinitionOutput> {
@@ -61,7 +60,6 @@ export class TagResolver {
     name: 'updateTagDefinition',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async updateTagDefinition(
     @Args('input') input: UpdateTagDefinitionInput,
   ): Promise<UpdateTagDefinitionOutput> {

--- a/apps/api/src/product/category.resolver.ts
+++ b/apps/api/src/product/category.resolver.ts
@@ -1,7 +1,7 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
@@ -31,6 +31,7 @@ export class CategoryResolver {
   ) {}
 
   @Query(() => CategoriesPage, { name: 'categories' })
+  @OptionalAuth()
   async categories(@Args() args: CategoriesArgs): Promise<CategoriesPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(CategoriesArgs, args)
     const cursor = await this.categoryService.find(filter)
@@ -38,6 +39,7 @@ export class CategoryResolver {
   }
 
   @Query(() => Category, { name: 'category', nullable: true })
+  @OptionalAuth()
   async category(@Args('id', { type: () => ID }) id: string): Promise<Category> {
     const category = await this.categoryService.findOneByID(id)
     if (!category) {
@@ -48,6 +50,7 @@ export class CategoryResolver {
   }
 
   @Query(() => Category, { name: 'categoryRoot' })
+  @OptionalAuth()
   async categoryRoot(): Promise<Category> {
     const category = await this.categoryService.findRoot()
     if (!category) {
@@ -58,6 +61,7 @@ export class CategoryResolver {
   }
 
   @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
   async categorySchema(): Promise<ModelEditSchema> {
     return {
       create: {
@@ -110,7 +114,6 @@ export class CategoryResolver {
     name: 'createCategory',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async createCategory(
     @Args('input') input: CreateCategoryInput,
     @AuthUser() user: ReqUser,
@@ -125,7 +128,6 @@ export class CategoryResolver {
     name: 'updateCategory',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async updateCategory(
     @Args('input') input: UpdateCategoryInput,
     @AuthUser() user: ReqUser,
@@ -140,7 +142,6 @@ export class CategoryResolver {
   }
 
   @Mutation(() => DeleteOutput, { name: 'deleteCategory', nullable: true })
-  @UseGuards(AuthGuard)
   async deleteCategory(@Args('input') input: DeleteInput): Promise<DeleteOutput> {
     const deleted = await this.categoryService.delete(input)
     if (!deleted) {

--- a/apps/api/src/product/item.resolver.ts
+++ b/apps/api/src/product/item.resolver.ts
@@ -1,15 +1,14 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
 import { Tag, TagPage } from '@src/process/tag.model'
-
-import { CategoriesPage, Category } from './category.model'
+import { CategoriesPage, Category } from '@src/product/category.model'
 import {
   CreateItemInput,
   CreateItemOutput,
@@ -21,10 +20,10 @@ import {
   ItemVariantsArgs,
   UpdateItemInput,
   UpdateItemOutput,
-} from './item.model'
-import { ItemSchemaService } from './item.schema'
-import { ItemService } from './item.service'
-import { Variant, VariantsPage } from './variant.model'
+} from '@src/product/item.model'
+import { ItemSchemaService } from '@src/product/item.schema'
+import { ItemService } from '@src/product/item.service'
+import { Variant, VariantsPage } from '@src/product/variant.model'
 
 @Resolver(() => Item)
 export class ItemResolver {
@@ -35,6 +34,7 @@ export class ItemResolver {
   ) {}
 
   @Query(() => ItemsPage, { name: 'items' })
+  @OptionalAuth()
   async items(@Args() args: ItemsArgs): Promise<ItemsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(ItemsArgs, args)
     const cursor = await this.itemService.find(filter)
@@ -42,6 +42,7 @@ export class ItemResolver {
   }
 
   @Query(() => Item, { name: 'item', nullable: true })
+  @OptionalAuth()
   async item(@Args('id', { type: () => ID }) id: string): Promise<Item> {
     const item = await this.itemService.findOneByID(id)
     if (!item) {
@@ -52,6 +53,7 @@ export class ItemResolver {
   }
 
   @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
   async itemSchema(): Promise<ModelEditSchema> {
     return {
       create: {
@@ -87,7 +89,6 @@ export class ItemResolver {
   }
 
   @Mutation(() => CreateItemOutput, { name: 'createItem', nullable: true })
-  @UseGuards(AuthGuard)
   async createItem(
     @Args('input') input: CreateItemInput,
     @AuthUser() user: ReqUser,
@@ -103,7 +104,6 @@ export class ItemResolver {
   }
 
   @Mutation(() => UpdateItemOutput, { name: 'updateItem', nullable: true })
-  @UseGuards(AuthGuard)
   async updateItem(
     @Args('input') input: UpdateItemInput,
     @AuthUser() user: ReqUser,
@@ -118,7 +118,6 @@ export class ItemResolver {
   }
 
   @Mutation(() => DeleteOutput, { name: 'deleteItem', nullable: true })
-  @UseGuards(AuthGuard)
   async deleteItem(@Args('input') input: DeleteInput): Promise<DeleteOutput> {
     const item = await this.itemService.delete(input)
     if (!item) {

--- a/apps/api/src/product/variant.resolver.ts
+++ b/apps/api/src/product/variant.resolver.ts
@@ -1,15 +1,14 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
 import { Tag, TagPage } from '@src/process/tag.model'
-
-import { Item, ItemsPage } from './item.model'
+import { Item, ItemsPage } from '@src/product/item.model'
 import {
   CreateVariantInput,
   CreateVariantOutput,
@@ -27,9 +26,9 @@ import {
   VariantsArgs,
   VariantsPage,
   VariantTagsArgs,
-} from './variant.model'
-import { VariantSchemaService } from './variant.schema'
-import { VariantService } from './variant.service'
+} from '@src/product/variant.model'
+import { VariantSchemaService } from '@src/product/variant.schema'
+import { VariantService } from '@src/product/variant.service'
 
 @Resolver(() => Variant)
 export class VariantResolver {
@@ -40,6 +39,7 @@ export class VariantResolver {
   ) {}
 
   @Query(() => VariantsPage, { name: 'variants' })
+  @OptionalAuth()
   async variants(@Args() args: VariantsArgs): Promise<VariantsPage> {
     const [parsedArgs, filter] = await this.transform.paginationArgs(VariantsArgs, args)
     const cursor = await this.variantService.find(filter)
@@ -47,6 +47,7 @@ export class VariantResolver {
   }
 
   @Query(() => Variant, { name: 'variant', nullable: true })
+  @OptionalAuth()
   async variant(@Args('id', { type: () => ID }) id: string): Promise<Variant> {
     const variant = await this.variantService.findOneByID(id)
     if (!variant) {
@@ -57,6 +58,7 @@ export class VariantResolver {
   }
 
   @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
   async variantSchema(): Promise<ModelEditSchema> {
     return {
       create: {
@@ -116,7 +118,6 @@ export class VariantResolver {
     name: 'createVariant',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async createVariant(
     @Args('input') input: CreateVariantInput,
     @AuthUser() user: ReqUser,
@@ -134,7 +135,6 @@ export class VariantResolver {
     name: 'updateVariant',
     nullable: true,
   })
-  @UseGuards(AuthGuard)
   async updateVariant(
     @Args('input') input: UpdateVariantInput,
     @AuthUser() user: ReqUser,
@@ -149,7 +149,6 @@ export class VariantResolver {
   }
 
   @Mutation(() => DeleteOutput, { name: 'deleteVariant', nullable: true })
-  @UseGuards(AuthGuard)
   async deleteVariant(@Args('input') input: DeleteInput): Promise<DeleteOutput> {
     const variant = await this.variantService.delete(input)
     if (!variant) {

--- a/apps/api/src/search/search.resolver.ts
+++ b/apps/api/src/search/search.resolver.ts
@@ -1,10 +1,10 @@
 import { Args, Query, Resolver } from '@nestjs/graphql'
 
+import { OptionalAuth } from '@src/auth/decorators'
 import { BadRequestErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
-
-import { SearchArgs, SearchResultPage } from './search.model'
-import { SearchService } from './search.service'
+import { SearchArgs, SearchResultPage } from '@src/search/search.model'
+import { SearchService } from '@src/search/search.service'
 
 @Resolver(() => SearchResultPage)
 export class SearchResolver {
@@ -14,6 +14,7 @@ export class SearchResolver {
   ) {}
 
   @Query(() => SearchResultPage, { name: 'search' })
+  @OptionalAuth()
   async search(@Args() args: SearchArgs): Promise<any> {
     const result = SearchArgs.schema.safeParse(args)
     if (!result.success) {

--- a/apps/api/src/users/org.resolver.ts
+++ b/apps/api/src/users/org.resolver.ts
@@ -1,11 +1,10 @@
-import { UseGuards } from '@nestjs/common'
 import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
-import { AuthGuard, AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
 import { Change } from '@src/changes/change.model'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
-
 import {
   CreateOrgInput,
   CreateOrgOutput,
@@ -13,9 +12,9 @@ import {
   OrgUsersArgs,
   UpdateOrgInput,
   UpdateOrgOutput,
-} from './org.model'
-import { OrgService } from './org.service'
-import { User, UserPage } from './users.model'
+} from '@src/users/org.model'
+import { OrgService } from '@src/users/org.service'
+import { User, UserPage } from '@src/users/users.model'
 
 @Resolver(() => Org)
 export class OrgResolver {
@@ -25,6 +24,7 @@ export class OrgResolver {
   ) {}
 
   @Query(() => Org, { name: 'org', nullable: true })
+  @OptionalAuth()
   async org(@Args('id', { type: () => ID }) id: string) {
     const org = await this.orgService.findOneByID(id)
     if (!org) {
@@ -42,7 +42,6 @@ export class OrgResolver {
   }
 
   @Mutation(() => CreateOrgOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async createOrg(
     @Args('input') input: CreateOrgInput,
     @AuthUser() user: ReqUser,
@@ -57,7 +56,6 @@ export class OrgResolver {
   }
 
   @Mutation(() => UpdateOrgOutput, { nullable: true })
-  @UseGuards(AuthGuard)
   async updateOrg(
     @Args('input') input: UpdateOrgInput,
     @AuthUser() user: ReqUser,

--- a/apps/api/src/users/users.resolver.ts
+++ b/apps/api/src/users/users.resolver.ts
@@ -1,11 +1,11 @@
 import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
+import { OptionalAuth } from '@src/auth/decorators'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
-
-import { Org, OrgsPage } from './org.model'
-import { User, UsersOrgsArgs } from './users.model'
-import { UsersService } from './users.service'
+import { Org, OrgsPage } from '@src/users/org.model'
+import { User, UsersOrgsArgs } from '@src/users/users.model'
+import { UsersService } from '@src/users/users.service'
 
 @Resolver(() => User)
 export class UsersResolver {
@@ -15,6 +15,7 @@ export class UsersResolver {
   ) {}
 
   @Query(() => User, { name: 'user', nullable: true })
+  @OptionalAuth()
   async user(@Args('id', { type: () => ID }) id: string) {
     const user = await this.usersService.findOneByID(id)
     if (!user) {


### PR DESCRIPTION
With the recent upgrade of the better-auth integration, the
AuthGuard was set as global. This is better but it means if we
want users to access anything anonymously we must mark that
Query with OptionalAuth.
