### PR TITLE
chore(ci): Only install chromium for PR e2e (full e2e on main)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -111,7 +111,7 @@ jobs:
           NODE_ENV: test
           TEST_DATABASE_URL: 'cockroachdb://root@localhost:26257/defaultdb?sslmode=disable'
 
-      - run: pnpm --filter=@sageleaf/e2e-frontend exec playwright install --with-deps
+      - run: pnpm --filter=@sageleaf/e2e-frontend exec playwright install --with-deps chromium
       - run: pnpm exec nx affected -t e2e:ci
         env:
           NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
@@ -146,7 +146,7 @@ jobs:
           NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
           NODE_ENV: test
 
-      - run: pnpm --filter=@sageleaf/e2e-frontend exec playwright install --with-deps
+      - run: pnpm --filter=@sageleaf/e2e-frontend exec playwright install --with-deps chromium
       - run: pnpm exec nx affected -t e2e:ci
         env:
           NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit Playwright install to Chromium in PR e2e runs to speed up CI and reduce dependency footprint. Main keeps full browser installs for complete e2e coverage.

<sup>Written for commit 4810af3043978175b1723ff0d25f5d14a3e5f686. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

