### PR TITLE
fix(api): Add script for updating the GraphQL schema

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "start:prod": "node dist/main",
     "codegen": "graphql-codegen --config graphql-codegen.ts",
     "codegen:db": "./db-defs.sh",
+    "codegen:schema": "SCHEMA_GEN=1 nest start",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
@@ -112,9 +113,19 @@
           "{projectRoot}/temp/**/*"
         ]
       },
+      "codegen:schema": {
+        "cache": true,
+        "inputs": [
+          "{projectRoot}/src/**/*.ts"
+        ],
+        "outputs": [
+          "{projectRoot}/schema/schema.gql"
+        ]
+      },
       "build": {
         "dependsOn": [
-          "codegen*"
+          "codegen",
+          "codegen:db"
         ]
       },
       "test": {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -43,5 +43,8 @@ async function bootstrap() {
   app.useGlobalFilters(new HttpExceptionFilter())
   app.enableShutdownHooks()
   await app.listen(process.env.PORT || 4444)
+  if (process.env.SCHEMA_GEN) {
+    await app.close()
+  }
 }
 bootstrap()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a dedicated command to regenerate the API GraphQL schema without running the server, and updates docs to reflect the new flow. This makes schema updates quick and scriptable via Nx.

- **New Features**
  - New command: nx codegen:schema api regenerates apps/api/schema/schema.gql by starting Nest with SCHEMA_GEN=1 and exiting.
  - Added Nx target and npm script for codegen:schema; build now depends only on codegen and codegen:db.
  - Updated main.ts to close the app when SCHEMA_GEN is set.
  - Cleaned up AGENTS.md and updated instructions to use codegen:schema for schema regeneration.

- **Migration**
  - When the API schema changes, run nx codegen:schema api instead of nx build api to update schema.gql.

<sup>Written for commit 15e54c89c3c509671e78527548086a8046de2af5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

