### PR TITLE
feat(ci): Inject version/sha on build and to Posthog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           echo "affected=$(pnpm exec nx show projects --affected --with-target build --sep ',')" >> $GITHUB_OUTPUT
           echo "e2e-affected=$(pnpm exec nx show projects --affected --with-target e2e:ci --sep ',')" >> $GITHUB_OUTPUT
+          echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
   test:
     name: 'Build & Test API + Frontend'
@@ -103,6 +104,14 @@ jobs:
           NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_WRITE }}
           NODE_ENV: test
 
+      # Upload API source maps to PostHog
+      - name: Inject & upload source maps to PostHog
+        uses: PostHog/upload-source-maps@v2
+        with:
+          directory: apps/api/dist
+          project-id: ${{ secrets.POSTHOG_PROJECT_ID }}
+          api-key: ${{ secrets.POSTHOG_PERSONAL_API_KEY }}
+
   test-frontend:
     name: 'Build & Test Frontend'
     runs-on: ubuntu-latest
@@ -163,6 +172,7 @@ jobs:
       registry: ghcr.io/caj2
       image_name: sageleaf-api
       target: api
+      version: ${{ needs.nx-affected.outputs.version }}
 
   build-image-frontend:
     name: 'Build frontend images'
@@ -178,6 +188,7 @@ jobs:
       registry: ghcr.io/caj2
       image_name: sageleaf-frontend
       target: frontend
+      version: ${{ needs.nx-affected.outputs.version }}
 
   build-image-science:
     name: 'Build science images'

--- a/.github/workflows/oci-build-image.yml
+++ b/.github/workflows/oci-build-image.yml
@@ -4,19 +4,19 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        type: "string"
+        type: 'string'
         required: false
         default: '["ubuntu-latest"]'
         description: string of a JSON array describing the run target.
       context:
         type: string
         required: false
-        default: "."
-        description: "The image build context path"
+        default: '.'
+        description: 'The image build context path'
       target:
         type: string
         required: false
-        default: ""
+        default: ''
         description: |
           The target stage to build
       codeql_enabled:
@@ -29,7 +29,7 @@ on:
       download_artifact:
         type: string
         required: false
-        default: ""
+        default: ''
         description: |
           If provided, the name of a artifact that will be downloaded prior to building the dockerfile
       download_artifact_path:
@@ -44,19 +44,24 @@ on:
       registry:
         type: string
         required: false
-        default: "ghcr.io/caj2"
+        default: 'ghcr.io/caj2'
       push_in_pr:
         type: boolean
         required: false
         default: false
         description: |
           If true, images will be pushed in PRs
+      version:
+        type: string
+        required: false
+        description: |
+          If provided, the version of the image to build
     outputs:
       sha_tag:
-        description: "SHA tag for the image built, this includes the registry and image repository"
+        description: 'SHA tag for the image built, this includes the registry and image repository'
         value: ${{ jobs.build-image.outputs.sha_tag }}
       build_tag:
-        description: "Build tag, this is unique tag for this build, it does not include the registry and image repository"
+        description: 'Build tag, this is unique tag for this build, it does not include the registry and image repository'
         value: ${{ jobs.build-image.outputs.build_tag }}
     secrets:
       clone_token:
@@ -134,6 +139,14 @@ jobs:
           path: ${{ inputs.download_artifact_path }}
       - name: Display structure before build
         run: ls -R
+      - name: Get Short SHA
+        id: short-sha
+        run: |
+          export SHORT_SHA=$(git rev-parse --short HEAD)
+          export SHORT_SHA_TAG_ONLY=sha-$SHORT_SHA
+          echo "sha_short=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "build_tag=$SHORT_SHA_TAG_ONLY" >> $GITHUB_OUTPUT
+          echo "sha_tag=${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}:sha-$SHORT_SHA" >> $GITHUB_OUTPUT
       - name: Build Docker image
         id: build
         timeout-minutes: 25
@@ -144,13 +157,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ inputs.version }}
+            APP_SHA=${{ steps.short-sha.outputs.sha_short }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Get Short SHA
-        id: short-sha
-        run: |
-          export SHORT_SHA=$(git rev-parse --short HEAD)
-          export SHORT_SHA_TAG_ONLY=sha-$SHORT_SHA
-          echo "sha_short=$SHORT_SHA" >> $GITHUB_OUTPUT
-          echo "build_tag=$SHORT_SHA_TAG_ONLY" >> $GITHUB_OUTPUT
-          echo "sha_tag=${{ env.REGISTRY}}/${{ env.IMAGE_NAME }}:sha-$SHORT_SHA" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM node:25-slim AS base
+ARG APP_VERSION
+ARG APP_SHA
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
@@ -23,6 +25,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm deploy --legacy --filter=
 FROM base AS api
 COPY --from=api-build /prod/api /prod/api
 ENV NODE_ENV=production
+ENV APP_VERSION=$APP_VERSION
+ENV APP_SHA=$APP_SHA
 WORKDIR /prod/api
 EXPOSE 4444
 CMD [ "node", "dist/main" ]

--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -1,6 +1,7 @@
 import { join } from 'path'
 
 import { Global, Module } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { ClsModule } from 'nestjs-cls'
 import { AcceptLanguageResolver, HeaderResolver, I18nModule, QueryResolver } from 'nestjs-i18n'
 
@@ -30,6 +31,7 @@ import { ZService } from '@src/common/z.service'
     }),
   ],
   providers: [
+    ConfigService,
     TransformService,
     MeiliService,
     BaseSchemaService,

--- a/apps/api/src/common/posthog.service.spec.ts
+++ b/apps/api/src/common/posthog.service.spec.ts
@@ -1,0 +1,53 @@
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import { ClsService } from 'nestjs-cls'
+import { PostHog } from 'posthog-node'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { PosthogService } from '@src/common/posthog.service'
+
+vi.mock('posthog-node')
+
+describe('PosthogService', () => {
+  let service: PosthogService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PosthogService,
+        {
+          provide: ClsService,
+          useValue: { get: vi.fn() },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn((key: string) => {
+              if (key === 'posthog.apiKey') return 'test-key'
+              if (key === 'app.version') return '1.2.3'
+              if (key === 'app.sha') return 'abc123'
+              return undefined
+            }),
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get<PosthogService>(PosthogService)
+  })
+
+  test('should be defined', () => {
+    expect(service).toBeDefined()
+  })
+
+  test('should register with version and sha if apiKey is present', () => {
+    expect(PostHog).toHaveBeenCalledWith('test-key', { host: 'https://eu.i.posthog.com' })
+    const clientInstance = vi.mocked(PostHog).mock.instances[0]
+    expect(clientInstance.register).toHaveBeenCalledWith({
+      app: 'api',
+      app_version: '1.2.3',
+      app_sha: 'abc123',
+      environment: 'test', // Vitest sets NODE_ENV to test
+    })
+  })
+})

--- a/apps/api/src/common/posthog.service.ts
+++ b/apps/api/src/common/posthog.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnModuleDestroy } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
 import { ClsService } from 'nestjs-cls'
 import { PostHog } from 'posthog-node'
 
@@ -8,10 +9,21 @@ import type { UserSession } from '@src/auth/auth.guard'
 export class PosthogService implements OnModuleDestroy {
   private readonly client: PostHog | null
 
-  constructor(private readonly cls: ClsService) {
-    const apiKey = process.env.POSTHOG_API_KEY
+  constructor(
+    private readonly cls: ClsService,
+    private readonly config: ConfigService,
+  ) {
+    const apiKey = this.config.get<string | undefined>('posthog.apiKey')
     if (apiKey) {
       this.client = new PostHog(apiKey, { host: 'https://eu.i.posthog.com' })
+      const version = this.config.get<string>('app.version')
+      const sha = this.config.get<string>('app.sha')
+      this.client.register({
+        app: 'api',
+        app_version: version ?? 'dev',
+        app_sha: sha ?? '',
+        environment: process.env.NODE_ENV ?? 'unknown',
+      })
     } else {
       this.client = null
     }

--- a/apps/api/src/config/config.ts
+++ b/apps/api/src/config/config.ts
@@ -1,4 +1,8 @@
 export default (): Record<string, unknown> => ({
+  app: {
+    version: process.env.APP_VERSION ?? process.env.npm_package_version ?? '0.0.0',
+    sha: process.env.APP_SHA ?? 'unknown',
+  },
   auth: {
     jwt: {
       secret: process.env.JWT_SECRET,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Injects app version and git SHA into Docker builds and the API runtime, and reports them to PostHog for better release tracking. CI also uploads API source maps to PostHog.

- **New Features**
  - CI reads version from package.json and passes it to image builds; computes short SHA and sends both as APP_VERSION/APP_SHA build args.
  - Dockerfile sets APP_VERSION and APP_SHA as env vars in the API image.
  - Config exposes app.version and app.sha to the API.
  - PostHog client now uses ConfigService and registers app, app_version, app_sha, and environment (EU host).
  - CI uploads API source maps (apps/api/dist) via PostHog/upload-source-maps@v2.
  - Added unit test for PosthogService registration with version and SHA.

<sup>Written for commit ea7ee209a1ec07d30c5c0fc94dc74c570e5e60db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

