### PR TITLE
feat(sources): Enable cdn:// prefix

### DIFF
--- a/apps/api/src/changes/source.schema.test.ts
+++ b/apps/api/src/changes/source.schema.test.ts
@@ -57,6 +57,28 @@ describe('SourceSchemaService', () => {
       })
     })
 
+    it('accepts contentURL with cdn:// protocol', async () => {
+      await expect(
+        service.parseCreateInput({
+          type: SourceType.URL,
+          contentURL: 'cdn://sources/test.jpg',
+        }),
+      ).resolves.toMatchObject({
+        contentURL: 'cdn://sources/test.jpg',
+      })
+    })
+
+    it('shrinks full CDN contentURL to cdn:// protocol', async () => {
+      await expect(
+        service.parseCreateInput({
+          type: SourceType.URL,
+          contentURL: 'https://sage-leaf-sources.fra1.cdn.digitaloceanspaces.com/test.jpg',
+        }),
+      ).resolves.toMatchObject({
+        contentURL: 'cdn://sources/test.jpg',
+      })
+    })
+
     it('rejects contentURL with http:// instead of https://', async () => {
       await expect(
         service.parseCreateInput({

--- a/apps/api/src/changes/source.schema.ts
+++ b/apps/api/src/changes/source.schema.ts
@@ -10,9 +10,11 @@ import {
   UnlinkSourceInput,
   UpdateSourceInput,
 } from '@src/changes/source.model'
+import { expandCdnUrl, shrinkCdnUrl } from '@src/common/cdn'
 import { TransformInput, ZService } from '@src/common/z.service'
 
 export const JSONLD_CONTEXT: jsonld.ContextDefinition = {
+  '@vocab': 'http://schema.org/',
   kg: 'http://g.co/kg',
   wd: 'http://www.wikidata.org/entity/',
   wdt: 'http://www.wikidata.org/prop/direct/',
@@ -25,11 +27,17 @@ export const SourceIDSchema = z.string().meta({
   title: 'Source ID',
 })
 
+const ContentUrlSchema = z
+  .string()
+  .transform((v) => shrinkCdnUrl(v))
+  .pipe(z.string().regex(/^(https:\/\/|cdn:\/\/)/))
+  .optional()
+
 export const CreateSourceInputSchema = z.object({
   type: z.enum(SourceType),
   location: z.string().max(2048).optional(),
   content: z.record(z.string(), z.json()).optional(),
-  contentURL: z.url({ protocol: /^https$/ }).optional(),
+  contentURL: ContentUrlSchema,
   metadata: z.record(z.string(), z.json()).optional(),
 })
 export const CreateSourceInputJSONSchema = z.toJSONSchema(CreateSourceInputSchema)
@@ -39,7 +47,7 @@ export const UpdateSourceInputSchema = z.object({
   type: z.enum(SourceType).optional(),
   location: z.string().max(2048).optional(),
   content: z.record(z.string(), z.json()).optional(),
-  contentURL: z.url({ protocol: /^https$/ }).optional(),
+  contentURL: ContentUrlSchema,
   metadata: z.record(z.string(), z.json()).optional(),
 })
 export const UpdateSourceInputJSONSchema = z.toJSONSchema(UpdateSourceInputSchema)
@@ -80,7 +88,7 @@ const ModelTransform = z.transform((input: TransformInput) => {
   model.type = entity.type
   model.location = entity.location
   model.content = entity.content
-  model.contentURL = entity.contentURL
+  model.contentURL = expandCdnUrl(entity.contentURL)
   model.metadata = entity.metadata
   return model
 })

--- a/apps/api/src/common/cdn.test.ts
+++ b/apps/api/src/common/cdn.test.ts
@@ -1,0 +1,39 @@
+import { expandCdnUrl, shrinkCdnUrl } from './cdn'
+
+describe('CDN utils', () => {
+  describe('shrinkCdnUrl', () => {
+    it('shrinks known CDN prefixes', () => {
+      expect(
+        shrinkCdnUrl(
+          'https://sage-leaf-sources.fra1.cdn.digitaloceanspaces.com/off/00000758/1.400.jpg',
+        ),
+      ).toBe('cdn://sources/off/00000758/1.400.jpg')
+    })
+
+    it('leaves unknown URLs alone', () => {
+      expect(shrinkCdnUrl('https://example.com/test.jpg')).toBe('https://example.com/test.jpg')
+    })
+
+    it('handles null/undefined', () => {
+      expect(shrinkCdnUrl(null)).toBe(null)
+      expect(shrinkCdnUrl(undefined)).toBe(undefined)
+    })
+  })
+
+  describe('expandCdnUrl', () => {
+    it('expands known CDN prefixes', () => {
+      expect(expandCdnUrl('cdn://sources/off/00000758/1.400.jpg')).toBe(
+        'https://sage-leaf-sources.fra1.cdn.digitaloceanspaces.com/off/00000758/1.400.jpg',
+      )
+    })
+
+    it('leaves unknown URLs alone', () => {
+      expect(expandCdnUrl('https://example.com/test.jpg')).toBe('https://example.com/test.jpg')
+    })
+
+    it('handles null/undefined', () => {
+      expect(expandCdnUrl(null as any)).toBe(null)
+      expect(expandCdnUrl(undefined)).toBe(undefined)
+    })
+  })
+})

--- a/apps/api/src/common/cdn.ts
+++ b/apps/api/src/common/cdn.ts
@@ -1,0 +1,34 @@
+export const CDN_PREFIXES: Record<string, string> = {
+  'cdn://sources': 'https://sage-leaf-sources.fra1.cdn.digitaloceanspaces.com',
+}
+
+/**
+ * Expands a CDN URL from its internal format (e.g., cdn://sources/...)
+ * to its full public URL.
+ */
+export function expandCdnUrl(url?: string): string | undefined {
+  if (!url) return url
+
+  for (const [prefix, replacement] of Object.entries(CDN_PREFIXES)) {
+    if (url.startsWith(prefix)) {
+      return url.replace(prefix, replacement)
+    }
+  }
+
+  return url
+}
+
+/**
+ * Shrinks a full CDN URL to its internal format (e.g., cdn://sources/...).
+ */
+export function shrinkCdnUrl(url: string | undefined | null): string | undefined | null {
+  if (!url) return url
+
+  for (const [prefix, replacement] of Object.entries(CDN_PREFIXES)) {
+    if (url.startsWith(replacement)) {
+      return url.replace(replacement, prefix)
+    }
+  }
+
+  return url
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable `cdn://` URLs for source `contentURL`. Inputs accept `cdn://` or full CDN `https://` and normalize to `cdn://` internally; responses expand back to full public URLs.

- **New Features**
  - Added CDN utils: `expandCdnUrl` and `shrinkCdnUrl` with tests.
  - Schema now accepts `contentURL` with `https://` or `cdn://` and auto-shrinks known CDN hosts.
  - Output expands `cdn://` to full CDN `https://`, so API responses are unchanged.

<sup>Written for commit 1c1acd7ec7c8e5bd114a8ce5ca6d2c020d4901e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

