### PR TITLE
fix(frontend): Inline vue/shared to fix runtime errors

### DIFF
--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -117,6 +117,9 @@ export default defineNuxtConfig({
   },
 
   nitro: {
+    externals: {
+      inline: ['@vue/shared'],
+    },
     rollupConfig: {
       output: {
         sourcemapExcludeSources: false,

--- a/apps/science/nuxt.config.ts
+++ b/apps/science/nuxt.config.ts
@@ -96,5 +96,11 @@ export default defineNuxtConfig({
     classSuffix: '',
   },
 
+  nitro: {
+    externals: {
+      inline: ['@vue/shared'],
+    },
+  },
+
   compatibilityDate: '2026-02-12',
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Inline `@vue/shared` in Nitro externals for the frontend and science Nuxt apps to fix runtime errors in server builds.
This ensures `@vue/shared` is bundled instead of externalized, preventing resolution issues at runtime.

<sup>Written for commit 95cd8518a7931812080dbcb9db7a72598cbf87ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

