### PR TITLE
chore(build): Move to sage-eco org, combine frontend and science into web

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@
 ## Workspace Structure
 
 ```
-sage-app/
+sageleaf/
 ├── apps/
 │   ├── api/          # @sageleaf/api       — NestJS GraphQL backend
 │   ├── frontend/     # @sageleaf/frontend  — Nuxt web & mobile app
@@ -43,10 +43,10 @@ pnpm install            # Install all workspace deps (always at root)
 
 See `.claude/rules/` for detailed, workspace-scoped guidance:
 
-| File | Scope | Contents |
-|------|-------|----------|
-| `monorepo.md` | All files | AI quick start, workflows, pitfalls, coding standards |
-| `api.md` | `apps/api/**` | NestJS, GraphQL, MikroORM, API commands |
-| `frontend.md` | `apps/frontend/**` | Nuxt, Vue, Tauri mobile, frontend commands |
-| `science.md` | `apps/science/**` | Science app (desktop, data viz focus) |
-| `ui.md` | `packages/ui/**` | Shared UI component library |
+| File          | Scope              | Contents                                              |
+| ------------- | ------------------ | ----------------------------------------------------- |
+| `monorepo.md` | All files          | AI quick start, workflows, pitfalls, coding standards |
+| `api.md`      | `apps/api/**`      | NestJS, GraphQL, MikroORM, API commands               |
+| `frontend.md` | `apps/frontend/**` | Nuxt, Vue, Tauri mobile, frontend commands            |
+| `science.md`  | `apps/science/**`  | Science app (desktop, data viz focus)                 |
+| `ui.md`       | `packages/ui/**`   | Shared UI component library                           |

--- a/.claude/rules/monorepo.md
+++ b/.claude/rules/monorepo.md
@@ -257,7 +257,7 @@ Common test issues:
 
 ```bash
 git clone <repository-url>
-cd sage-app
+cd sageleaf
 pnpm install
 ```
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 .gitignore
 **/*.md
 **/dist
+.nx
+target

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ This document provides an overview of the Sage monorepo and instructions for cod
 ### Workspace Structure
 
 ```
-sage-app/
+sageleaf/
 ├── apps/
 │   ├── api/          # @sageleaf/api - NestJS GraphQL backend
 │   ├── frontend/     # @sageleaf/frontend - Nuxt web & mobile app
@@ -678,7 +678,7 @@ Helm charts located in `deploy/charts/`:
 
    ```bash
    git clone <repository-url>
-   cd sage-app
+   cd sageleaf
    pnpm install
    ```
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,15 +170,15 @@ jobs:
       security-events: write
       id-token: write
     with:
-      registry: ghcr.io/caj2
+      registry: ghcr.io/sage-eco
       image_name: sageleaf-api
       target: api
       version: ${{ needs.nx-affected.outputs.version }}
 
-  build-image-frontend:
-    name: 'Build frontend images'
+  build-image-web:
+    name: 'Build web image'
     uses: ./.github/workflows/oci-build-image.yml
-    if: ${{ !failure() && !cancelled() && contains(needs.nx-affected.outputs.affected, '@sageleaf/frontend') }}
+    if: ${{ !failure() && !cancelled() && (contains(needs.nx-affected.outputs.affected, '@sageleaf/frontend') || contains(needs.nx-affected.outputs.affected, '@sageleaf/science')) }}
     needs: [nx-affected, test, test-frontend]
     permissions:
       contents: read
@@ -186,22 +186,7 @@ jobs:
       security-events: write
       id-token: write
     with:
-      registry: ghcr.io/caj2
-      image_name: sageleaf-frontend
-      target: frontend
+      registry: ghcr.io/sage-eco
+      image_name: sageleaf-web
+      target: web
       version: ${{ needs.nx-affected.outputs.version }}
-
-  build-image-science:
-    name: 'Build science images'
-    uses: ./.github/workflows/oci-build-image.yml
-    if: ${{ !failure() && !cancelled() && contains(needs.nx-affected.outputs.affected, '@sageleaf/science') }}
-    needs: [nx-affected, test, test-frontend]
-    permissions:
-      contents: read
-      packages: write
-      security-events: write
-      id-token: write
-    with:
-      registry: ghcr.io/caj2
-      image_name: sageleaf-science
-      target: science

--- a/.github/workflows/oci-build-image.yml
+++ b/.github/workflows/oci-build-image.yml
@@ -44,7 +44,7 @@ on:
       registry:
         type: string
         required: false
-        default: 'ghcr.io/caj2'
+        default: 'ghcr.io/sage-eco'
       push_in_pr:
         type: boolean
         required: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["apps/frontend/src-tauri"]
 resolver = "3"
 
 [workspace.package]
-repository = "https://github.com/CAJ2/sage-app"
+repository = "https://github.com/sage-eco/sageleaf"
 authors = ["Christian Johansen <johansen.christian.a@gmail.com>"]
 version = "0.1.0"
 license = "AGPL-3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,14 +37,6 @@ COPY packages/ui /usr/src/app/packages/ui/
 COPY apps/api/schema/schema.gql /usr/src/app/apps/api/schema/
 RUN pnpm --filter=@sageleaf/frontend exec nuxi prepare
 RUN nx run-many -p frontend -t build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm deploy --legacy --filter=...frontend --prod /prod/frontend
-
-FROM base AS frontend
-COPY --from=frontend-build /prod/frontend /prod/frontend
-ENV NODE_ENV=production
-WORKDIR /prod/frontend
-EXPOSE 3000
-CMD [ "node", ".output/server/index.mjs" ]
 
 FROM build AS science-build
 COPY apps/science /usr/src/app/apps/science
@@ -52,11 +44,14 @@ COPY packages/ui /usr/src/app/packages/ui/
 COPY apps/api/schema/schema.gql /usr/src/app/apps/api/schema/
 RUN pnpm --filter=@sageleaf/science exec nuxi prepare
 RUN nx run-many -p science -t build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm deploy --legacy --filter=...science --prod /prod/science
 
-FROM base AS science
-COPY --from=science-build /prod/science /prod/science
+FROM base AS web
+COPY --from=frontend-build /usr/src/app/apps/frontend/.output /prod/frontend/.output
+COPY --from=science-build /usr/src/app/apps/science/.output /prod/science/.output
 ENV NODE_ENV=production
-WORKDIR /prod/science
+ENV APP_VERSION=$APP_VERSION
+ENV APP_SHA=$APP_SHA
+RUN printf '#!/bin/sh\nexec node /prod/${APP}/.output/server/index.mjs\n' > /start.sh \
+    && chmod +x /start.sh
 EXPOSE 3000
-CMD [ "node", ".output/server/index.mjs" ]
+CMD ["/start.sh"]

--- a/deploy/charts/api/values.yaml
+++ b/deploy/charts/api/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/caj2/sageleaf-api
+  repository: ghcr.io/sage-eco/sageleaf-api
   pullPolicy: Always
   tag: 'main'
 
@@ -32,7 +32,7 @@ podSecurityContext:
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
@@ -50,8 +50,7 @@ env:
 ingress:
   enabled: false
   className: ''
-  annotations:
-    {}
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -66,8 +65,7 @@ ingress:
 
 ingressRoute:
   enabled: false
-  annotations:
-    {}
+  annotations: {}
   routes:
     - kind: Rule
       match: Host(`www.example.com`) && PathPrefix(`/images`)

--- a/deploy/charts/frontend/templates/deployment.yaml
+++ b/deploy/charts/frontend/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - secretRef:
                 name: {{ .Values.env.secret }}
                 optional: true
+          env:
+            - name: APP
+              value: {{ .Values.env.app }}
           livenessProbe:
             httpGet:
               path: /health

--- a/deploy/charts/frontend/values.yaml
+++ b/deploy/charts/frontend/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/caj2/sageleaf-frontend
+  repository: ghcr.io/sage-eco/sageleaf-web
   pullPolicy: Always
   tag: 'main'
 
@@ -46,6 +46,7 @@ service:
 env:
   configMap: frontend-configmap
   secret: frontend-secret
+  app: frontend
 
 ingress:
   enabled: false

--- a/deploy/charts/science/templates/deployment.yaml
+++ b/deploy/charts/science/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             - secretRef:
                 name: {{ .Values.env.secret }}
                 optional: true
+          env:
+            - name: APP
+              value: {{ .Values.env.app }}
           livenessProbe:
             httpGet:
               path: /health

--- a/deploy/charts/science/values.yaml
+++ b/deploy/charts/science/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/caj2/sageleaf-science
+  repository: ghcr.io/sage-eco/sageleaf-web
   pullPolicy: Always
   tag: 'main'
 
@@ -46,6 +46,7 @@ service:
 env:
   configMap: science-configmap
   secret: science-secret
+  app: science
 
 ingress:
   enabled: false


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move the repo to the `sage-eco` org and merge `@sageleaf/frontend` and `@sageleaf/science` into a single `sageleaf-web` image that selects the app at runtime via `APP`. Simplifies builds and deployments.

- **Refactors**
  - CI: default registry set to `ghcr.io/sage-eco`; replaced separate frontend/science jobs with a single `build-image-web` (target `web`), image names now `sageleaf-api` and `sageleaf-web`.
  - Dockerfile: build both apps and run one image with `/start.sh` using `APP`; removed separate runtime stages; exports `APP_VERSION` and `APP_SHA`.
  - Deploy: frontend/science charts now use `ghcr.io/sage-eco/sageleaf-web` and set `env.APP`; API chart points to `ghcr.io/sage-eco/sageleaf-api`; minor YAML cleanups.
  - Docs/meta: rename workspace path `sage-app` → `sageleaf`; update repository URL; add `.nx` and `target` to `.dockerignore`.

- **Migration**
  - Update deployments to `ghcr.io/sage-eco/sageleaf-api` and `ghcr.io/sage-eco/sageleaf-web`.
  - Ensure `APP` is set to `frontend` or `science` for web containers.
  - Use `sageleaf` as the repo directory in local scripts and docs.

<sup>Written for commit 384a79e4c714dc5fe08dbee72636b666dcaf13df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

