### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,10 +1,7 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -21,66 +18,36 @@
   "targetDefaults": {
     "build": {
       "cache": true,
-      "inputs": [
-        "production",
-        "^production"
-      ],
+      "inputs": ["production", "^production"],
       "outputs": [
         "{projectRoot}/dist",
         "{projectRoot}/temp",
         "{projectRoot}/.nuxt",
         "{projectRoot}/.output"
       ],
-      "dependsOn": [
-        "^build"
-      ]
+      "dependsOn": ["^build"]
     },
     "lint": {
       "cache": true,
-      "inputs": [
-        "default",
-        "^production"
-      ],
-      "dependsOn": [
-        "^build"
-      ]
+      "inputs": ["default", "^production"],
+      "dependsOn": ["^build"]
     },
     "lint:ci": {
       "cache": false,
-      "inputs": [
-        "default",
-        "^production"
-      ],
-      "dependsOn": [
-        "^build"
-      ]
+      "inputs": ["default", "^production"],
+      "dependsOn": ["^build"]
     },
     "test": {
       "cache": true,
-      "inputs": [
-        "default",
-        "^default",
-        "{workspaceRoot}/vitest.config.ts"
-      ],
-      "outputs": [
-        "{workspaceRoot}/coverage/{projectRoot}",
-        "{projectRoot}/coverage"
-      ],
+      "inputs": ["default", "^default", "{workspaceRoot}/vitest.config.ts"],
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}", "{projectRoot}/coverage"],
       "executor": "@nx/vitest:vitest"
     },
     "generate": {
       "cache": true,
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "outputs": [
-        "{projectRoot}/.output",
-        "{projectRoot}/.nuxt"
-      ],
-      "dependsOn": [
-        "^build"
-      ]
+      "inputs": ["production", "^production"],
+      "outputs": ["{projectRoot}/.output", "{projectRoot}/.nuxt"],
+      "dependsOn": ["^build"]
     }
   },
   "nxCloudId": "69cc5e5d4b3937b7e705fffb",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/69cc5e5b1fde65b65d7fe9cf/workspaces/69cc5e5d4b3937b7e705fffb

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up Nx Cloud for the Nx workspace to enable distributed caching and GitHub integration, speeding up CI and local runs. Access the workspace at https://cloud.nx.app/orgs/69cc5e5b1fde65b65d7fe9cf/workspaces/69cc5e5d4b3937b7e705fffb.

- **Bug Fixes**
  - Reformatted `nx.json` to match project formatting rules.

- **Migration**
  - No CI? Run `npx nx generate ci-workflow`.

<sup>Written for commit 53e5b029c0c36367509b5b0ca1c83ed0be57a9be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

