### PR TITLE
fix(science): Fix edit form not rendering

### DIFF
--- a/packages/ui/app/components/model/Form.vue
+++ b/packages/ui/app/components/model/Form.vue
@@ -129,11 +129,11 @@ if (modelId !== 'new' && changeId) {
     { immediate: true },
   )
   watch(
-    changeResult,
-    (result) => {
-      if (result?.change?.edits.nodes && result.change.edits.nodes.length > 0) {
+    [changeResult, jsonSchema],
+    ([result, schema]) => {
+      if (schema && result?.change?.edits.nodes && result.change.edits.nodes.length > 0) {
         updateData.value = sanitizeFormData(
-          jsonSchema.value as JSONSchemaType<unknown>,
+          schema as JSONSchemaType<unknown>,
           result.change.edits.nodes[0]!.updateInput,
         )
       }
@@ -147,11 +147,11 @@ if (modelId !== 'new' && changeId) {
     enabled: useDirect.value,
   }))
   watch(
-    directResult,
-    (result) => {
-      if (result?.directEdit?.updateInput) {
+    [directResult, jsonSchema],
+    ([result, schema]) => {
+      if (schema && result?.directEdit?.updateInput) {
         updateData.value = sanitizeFormData(
-          jsonSchema.value as JSONSchemaType<unknown>,
+          schema as JSONSchemaType<unknown>,
           result.directEdit.updateInput,
         )
       }
@@ -164,11 +164,11 @@ if (modelId !== 'new' && changeId) {
     entityName,
   })
   watch(
-    result,
-    (result) => {
-      if (result?.directEdit?.id) {
+    [result, jsonSchema],
+    ([result, schema]) => {
+      if (schema && result?.directEdit?.id) {
         updateData.value = sanitizeFormData(
-          jsonSchema.value as JSONSchemaType<unknown>,
+          schema as JSONSchemaType<unknown>,
           result.directEdit.updateInput,
         )
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the model edit form not rendering by waiting for `jsonSchema` before sanitizing update inputs. The form now renders reliably for both change-based and direct edits.

- **Bug Fixes**
  - Updated watchers to observe `[result, jsonSchema]` and guard `sanitizeFormData` until the schema is available, preventing undefined-schema errors across change, direct, and submit flows.

<sup>Written for commit cb0aa5ab47fe808079bb73b7956cb67b786a5063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

