### PR TITLE
fix(build): Include scanleaf in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY apps/api/package.json /usr/src/app/apps/api/
 COPY apps/frontend/package.json /usr/src/app/apps/frontend/
 COPY apps/science/package.json /usr/src/app/apps/science/
 COPY packages/ui/package.json /usr/src/app/packages/ui/
+COPY packages/scanleaf/package.json /usr/src/app/packages/scanleaf/
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
@@ -34,6 +35,7 @@ CMD [ "node", "dist/main" ]
 FROM build AS frontend-build
 COPY apps/frontend /usr/src/app/apps/frontend
 COPY packages/ui /usr/src/app/packages/ui/
+COPY packages/scanleaf /usr/src/app/packages/scanleaf/
 COPY apps/api/schema/schema.gql /usr/src/app/apps/api/schema/
 RUN pnpm --filter=@sageleaf/frontend exec nuxi prepare
 RUN nx run-many -p frontend -t build


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include `packages/scanleaf` in the Docker build to fix missing workspace dependency errors and unblock the frontend build. We now copy `packages/scanleaf/package.json` before `pnpm install` and the `packages/scanleaf` sources in the frontend build stage.

<sup>Written for commit c391999a7f95af32a3c921126eda7100da829d5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

