### PR TITLE
fix(build): Expose app sha through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 FROM base AS build
+ARG APP_SHA
+ENV APP_SHA=$APP_SHA
 RUN npm install -g pnpm@latest-10
 RUN pnpm add -g nx@latest
 COPY package.json pnpm-*.yaml nx.json /usr/src/app/

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -7,7 +7,16 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 import { version } from './package.json'
 
-const gitSha = execSync('git rev-parse --short HEAD').toString().trim()
+const getGitSha = () => {
+  if (process.env.APP_SHA) return process.env.APP_SHA
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return ''
+  }
+}
+
+const gitSha = getGitSha()
 const buildDate = new Date().toISOString()
 
 // Set by Tauri CLI when running on a real device over WiFi.

--- a/apps/science/nuxt.config.ts
+++ b/apps/science/nuxt.config.ts
@@ -7,7 +7,16 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 import { version } from './package.json'
 
-const gitSha = execSync('git rev-parse --short HEAD').toString().trim()
+const getGitSha = () => {
+  if (process.env.APP_SHA) return process.env.APP_SHA
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return ''
+  }
+}
+
+const gitSha = getGitSha()
 const buildDate = new Date().toISOString()
 export default defineNuxtConfig({
   devtools: { enabled: true },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose the Git SHA in Docker builds and make Nuxt builds resilient when Git data isn’t available. This keeps version info in CI and prevents build errors when `.git` isn’t present.

- **Bug Fixes**
  - Docker: add `ARG APP_SHA` and `ENV APP_SHA` to pass the SHA during build.
  - Nuxt (`apps/frontend`, `apps/science`): read `APP_SHA` first; fall back to `git rev-parse --short HEAD`; handle failures gracefully by returning an empty string.

- **Migration**
  - Pass the SHA in CI when building images: `docker build --build-arg APP_SHA=$(git rev-parse --short HEAD) .`

<sup>Written for commit b16bf6d5c339e4e0e173f69882f0387e3d3931b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

