### PR TITLE
feat(api): Program definitions

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 pnpm exec nx affected -t lint fmt build codegen test check:migrations
-git update-index --again
+git update-index --again :/:
 pnpm exec nx affected -t lint:ci fmt:ci

--- a/apps/api/schema/schema.gql
+++ b/apps/api/schema/schema.gql
@@ -1515,6 +1515,7 @@ enum TagType {
   ORG
   PLACE
   PROCESS
+  PROGRAM
   VARIANT
 }
 

--- a/apps/api/schema/schema.gql
+++ b/apps/api/schema/schema.gql
@@ -882,6 +882,7 @@ type Material implements Named {
 
   """The physical form or shape of the material (e.g. film, rigid, fibre)"""
   shape: String
+  synonyms: [String!]
 
   """
   If true, this is an internal technical classification not shown to end-users
@@ -1275,6 +1276,7 @@ type Region {
   country: Region
   county: Region
   createdAt: DateTime!
+  desc: String
   id: ID!
 
   """Minimum map zoom level at which this region should be displayed"""

--- a/apps/api/schema/schema.gql
+++ b/apps/api/schema/schema.gql
@@ -522,6 +522,42 @@ type CreateProcessOutput {
   process: Process
 }
 
+input CreateProgramInput {
+  """Sources to associate with this change"""
+  addSources: [SourceInput!]
+
+  """If true, immediately apply (merge) the change after creation"""
+  apply: Boolean
+
+  """Details for a new change to create for this edit"""
+  change: CreateChangeInput
+
+  """ID of an existing change to add this edit to"""
+  changeID: ID
+  desc: String
+  descTr: [TranslatedInput!]
+  instructions: JSONObject
+
+  """Language code for text input fields (BCP 47, e.g. "en")"""
+  lang: String
+  name: String
+  nameTr: [TranslatedInput!]
+  orgs: [ProgramOrgsInput!]
+  processes: [ProgramProcessesInput!]
+  region: ID
+
+  """IDs of sources to remove from this change"""
+  removeSources: [ID!]
+  social: JSONObject
+  status: String!
+  tags: [ProgramTagsInput!]
+}
+
+type CreateProgramOutput {
+  change: Change
+  program: Program
+}
+
 input CreateSourceInput {
   content: JSONObject
   contentURL: String
@@ -663,7 +699,7 @@ type EditEdge {
   node: Edit!
 }
 
-union EditModel = Category | Component | Item | Material | Org | Place | Process | Variant
+union EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant
 
 """Type of the model being edited"""
 enum EditModelType {
@@ -674,6 +710,7 @@ enum EditModelType {
   Org
   Place
   Process
+  Program
   Variant
 }
 
@@ -926,6 +963,7 @@ type Mutation {
   createOrg(input: CreateOrgInput!): CreateOrgOutput
   createPlace(input: CreatePlaceInput!): CreatePlaceOutput
   createProcess(input: CreateProcessInput!): CreateProcessOutput
+  createProgram(input: CreateProgramInput!): CreateProgramOutput
   createSource(input: CreateSourceInput!): CreateSourceOutput
   createTagDefinition(input: CreateTagDefinitionInput!): CreateTagDefinitionOutput
   createVariant(input: CreateVariantInput!): CreateVariantOutput
@@ -949,6 +987,7 @@ type Mutation {
   updateOrg(input: UpdateOrgInput!): UpdateOrgOutput
   updatePlace(input: UpdatePlaceInput!): UpdatePlaceOutput
   updateProcess(input: UpdateProcessInput!): UpdateProcessOutput
+  updateProgram(input: UpdateProgramInput!): UpdateProgramOutput
   updateSource(input: UpdateSourceInput!): UpdateSourceOutput
   updateTagDefinition(input: UpdateTagDefinitionInput!): UpdateTagDefinitionOutput
   updateVariant(input: UpdateVariantInput!): UpdateVariantOutput
@@ -1207,6 +1246,79 @@ input ProcessVariantInput {
   id: ID!
 }
 
+"""An administrative description of circular economy processes"""
+type Program implements Named {
+  createdAt: DateTime!
+  desc: String
+
+  """Audit history of changes to this program"""
+  history(after: String, before: String, first: Int, last: Int): ProgramHistoryPage!
+
+  """The ID of the model"""
+  id: ID!
+  instructions: JSONObject
+  name: String!
+
+  """Organizations involved in this program"""
+  orgs(after: String, before: String, first: Int, last: Int): OrgsPage!
+
+  """Processes run by this program"""
+  processes(after: String, before: String, first: Int, last: Int): ProcessPage!
+  region: Region
+  social: JSONObject
+  status: String!
+
+  """Metadata tags applied to this program"""
+  tags(after: String, before: String, first: Int, last: Int): TagPage!
+  updatedAt: DateTime!
+}
+
+type ProgramEdge {
+  cursor: String!
+  node: Program!
+}
+
+type ProgramHistory {
+  changes: Program
+  datetime: DateTime!
+  original: Program
+  program: Program!
+  user: User!
+}
+
+type ProgramHistoryEdge {
+  cursor: String!
+  node: ProgramHistory!
+}
+
+type ProgramHistoryPage {
+  edges: [ProgramHistoryEdge!]
+  nodes: [ProgramHistory!]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+input ProgramOrgsInput {
+  id: ID!
+  role: String
+}
+
+input ProgramProcessesInput {
+  id: ID!
+}
+
+input ProgramTagsInput {
+  id: ID!
+  meta: JSONObject
+}
+
+type ProgramsPage {
+  edges: [ProgramEdge!]
+  nodes: [Program!]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
 type Query {
   categories(after: String, before: String, first: Int, last: Int): CategoriesPage!
   category(id: ID!): Category
@@ -1236,6 +1348,9 @@ type Query {
   process(id: ID!): Process
   processSchema: ModelEditSchema
   processes(after: String, before: String, first: Int, last: Int, material: String, region: String): ProcessPage!
+  program(id: ID!): Program
+  programSchema: ModelEditSchema
+  programs(after: String, before: String, first: Int, last: Int): ProgramsPage!
   region(id: ID!): Region
   regions(after: String, before: String, first: Int, last: Int): RegionsPage!
   search(latlong: [Float!], limit: Int, offset: Int, query: String!, types: [SearchType!]): SearchResultPage!
@@ -1822,6 +1937,53 @@ type UpdateProcessOutput {
 
   """The process including the proposed changes"""
   process: Process
+}
+
+input UpdateProgramInput {
+  addOrgs: [ProgramOrgsInput!]
+  addProcesses: [ProgramProcessesInput!]
+
+  """Sources to associate with this change"""
+  addSources: [SourceInput!]
+  addTags: [ProgramTagsInput!]
+
+  """If true, immediately apply (merge) the change after creation"""
+  apply: Boolean
+
+  """Details for a new change to create for this edit"""
+  change: CreateChangeInput
+
+  """ID of an existing change to add this edit to"""
+  changeID: ID
+  desc: String
+  descTr: [TranslatedInput!]
+  id: ID!
+  instructions: JSONObject
+
+  """Language code for text input fields (BCP 47, e.g. "en")"""
+  lang: String
+  name: String
+  nameTr: [TranslatedInput!]
+  orgs: [ProgramOrgsInput!]
+  processes: [ProgramProcessesInput!]
+  region: ID
+  removeOrgs: [ID!]
+  removeProcesses: [ID!]
+
+  """IDs of sources to remove from this change"""
+  removeSources: [ID!]
+  removeTags: [ID!]
+  social: JSONObject
+  status: String
+  tags: [ProgramTagsInput!]
+}
+
+type UpdateProgramOutput {
+  change: Change
+
+  """The program as currently persisted in the database"""
+  currentProgram: Program
+  program: Program
 }
 
 input UpdateSourceInput {

--- a/apps/api/src/changes/change.enum.ts
+++ b/apps/api/src/changes/change.enum.ts
@@ -5,6 +5,7 @@ import { Place } from '@src/geo/place.model'
 import { Component } from '@src/process/component.model'
 import { Material } from '@src/process/material.model'
 import { Process } from '@src/process/process.model'
+import { Program } from '@src/process/program.model'
 import { Category } from '@src/product/category.model'
 import { Item } from '@src/product/item.model'
 import { Variant } from '@src/product/variant.model'
@@ -17,7 +18,8 @@ registerEnumType(ChangeStatus, {
 
 export const EditModel = createUnionType({
   name: 'EditModel',
-  types: () => [Place, Org, Component, Material, Process, Category, Item, Variant] as const,
+  types: () =>
+    [Place, Org, Component, Material, Process, Program, Category, Item, Variant] as const,
 })
 
 export enum EditModelType {
@@ -26,6 +28,7 @@ export enum EditModelType {
   Component = 'Component',
   Material = 'Material',
   Process = 'Process',
+  Program = 'Program',
   Category = 'Category',
   Item = 'Item',
   Variant = 'Variant',

--- a/apps/api/src/changes/change_map.service.ts
+++ b/apps/api/src/changes/change_map.service.ts
@@ -6,6 +6,7 @@ import _ from 'lodash'
 import { BadRequestErr } from '@src/common/exceptions'
 import { ComponentService } from '@src/process/component.service'
 import { ProcessService } from '@src/process/process.service'
+import { ProgramService } from '@src/process/program.service'
 import { CategoryService } from '@src/product/category.service'
 import { ItemService } from '@src/product/item.service'
 import { VariantService } from '@src/product/variant.service'
@@ -28,12 +29,14 @@ export class ChangeMapService {
     private readonly variantService: VariantService,
     private readonly componentService: ComponentService,
     private readonly processService: ProcessService,
+    private readonly programService: ProgramService,
   ) {
     this.serviceMap['Category'] = this.categoryService as IEntityService
     this.serviceMap['Item'] = this.itemService as IEntityService
     this.serviceMap['Variant'] = this.variantService as IEntityService
     this.serviceMap['Component'] = this.componentService as IEntityService
     this.serviceMap['Process'] = this.processService as IEntityService
+    this.serviceMap['Program'] = this.programService as IEntityService
   }
 
   findEditServices(entityName?: string) {

--- a/apps/api/src/common/i18n.service.ts
+++ b/apps/api/src/common/i18n.service.ts
@@ -31,6 +31,12 @@ export class I18nService {
 
   // Picks the appropriate translation for the current request language.
   tr(field: TranslatedField | string | undefined): string | undefined {
+    return this.pick(field) as string | undefined
+  }
+
+  // Generic helper to pick the appropriate localized value from a record
+  // based on the current request language preference.
+  pick<T>(field: Record<string, T> | string | undefined): T | string | undefined {
     if (typeof field === 'string') {
       return field
     }

--- a/apps/api/src/common/z.schema.ts
+++ b/apps/api/src/common/z.schema.ts
@@ -14,6 +14,11 @@ export type JSONObject = { [key: string]: JSONType }
 export const ZJSONObject = z.record(z.string(), z.json())
 export const ZTranslatedField = z.record(z.string(), z.string())
 
+export const RankSchema = z.object({
+  quality: z.number().optional(),
+})
+export type Rank = z.infer<typeof RankSchema>
+
 export const HTTPS_OR_ICON: core.$ZodURLParams = {
   protocol: /^https|icon$/,
 }

--- a/apps/api/src/db/migrations/.snapshot-sage.json
+++ b/apps/api/src/db/migrations/.snapshot-sage.json
@@ -342,6 +342,15 @@
           "nullable": true,
           "length": 255,
           "mappedType": "string"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "categories",
@@ -617,6 +626,15 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "items",
@@ -749,6 +767,15 @@
         },
         "desc": {
           "name": "desc",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "synonyms": {
+          "name": "synonyms",
           "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
@@ -1080,6 +1107,15 @@
           "primary": false,
           "nullable": false,
           "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "orgs",
@@ -1198,6 +1234,15 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "places",
@@ -1284,6 +1329,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "mappedType": "json"
+        },
+        "desc": {
+          "name": "desc",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "mappedType": "json"
         },
         "geo": {
@@ -1585,6 +1639,15 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "components",
@@ -1820,6 +1883,15 @@
         },
         "rules": {
           "name": "rules",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
           "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
@@ -2237,6 +2309,15 @@
           "nullable": true,
           "length": 255,
           "mappedType": "string"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "users",
@@ -4215,6 +4296,15 @@
           "nullable": true,
           "length": 255,
           "mappedType": "string"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
         }
       },
       "name": "variants",
@@ -4371,6 +4461,15 @@
         },
         "rules": {
           "name": "rules",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "rank": {
+          "name": "rank",
           "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,

--- a/apps/api/src/db/migrations/.snapshot-sage.json
+++ b/apps/api/src/db/migrations/.snapshot-sage.json
@@ -1441,6 +1441,219 @@
           "default": "current_timestamp()",
           "mappedType": "datetime"
         },
+        "name": {
+          "name": "name",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "json"
+        },
+        "desc": {
+          "name": "desc",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "social": {
+          "name": "social",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "enumItems": [
+            "PLANNED",
+            "ACTIVE",
+            "CLOSED"
+          ],
+          "mappedType": "enum"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 255,
+          "mappedType": "string"
+        }
+      },
+      "name": "programs",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "programs_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "programs_region_id_foreign": {
+          "constraintName": "programs_region_id_foreign",
+          "columnNames": [
+            "region_id"
+          ],
+          "localTableName": "public.programs",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.regions",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        }
+      },
+      "name": "programs_orgs",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "programs_orgs_pkey",
+          "columnNames": [
+            "program_id",
+            "org_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "programs_orgs_program_id_foreign": {
+          "constraintName": "programs_orgs_program_id_foreign",
+          "columnNames": [
+            "program_id"
+          ],
+          "localTableName": "public.programs_orgs",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.programs",
+          "updateRule": "cascade"
+        },
+        "programs_orgs_org_id_foreign": {
+          "constraintName": "programs_orgs_org_id_foreign",
+          "columnNames": [
+            "org_id"
+          ],
+          "localTableName": "public.programs_orgs",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.orgs",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "current_timestamp()",
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "default": "current_timestamp()",
+          "mappedType": "datetime"
+        },
         "region_id": {
           "name": "region_id",
           "type": "varchar(255)",
@@ -1829,6 +2042,7 @@
             "VARIANT",
             "COMPONENT",
             "PROCESS",
+            "PROGRAM",
             "ORG"
           ],
           "mappedType": "enum"
@@ -1927,6 +2141,82 @@
       ],
       "checks": [],
       "foreignKeys": {},
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        }
+      },
+      "name": "programs_tags",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "programs_tags_pkey",
+          "columnNames": [
+            "program_id",
+            "tag_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "programs_tags_program_id_foreign": {
+          "constraintName": "programs_tags_program_id_foreign",
+          "columnNames": [
+            "program_id"
+          ],
+          "localTableName": "public.programs_tags",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.programs",
+          "updateRule": "cascade"
+        },
+        "programs_tags_tag_id_foreign": {
+          "constraintName": "programs_tags_tag_id_foreign",
+          "columnNames": [
+            "tag_id"
+          ],
+          "localTableName": "public.programs_tags",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.tags",
+          "updateRule": "cascade"
+        }
+      },
       "nativeEnums": {}
     },
     {
@@ -2821,6 +3111,101 @@
             "user_id"
           ],
           "localTableName": "public.region_history",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.users",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "datetime": {
+          "name": "datetime",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "original": {
+          "name": "original",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "json"
+        }
+      },
+      "name": "program_history",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "program_history_pkey",
+          "columnNames": [
+            "program_id",
+            "datetime"
+          ],
+          "composite": true,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "program_history_program_id_foreign": {
+          "constraintName": "program_history_program_id_foreign",
+          "columnNames": [
+            "program_id"
+          ],
+          "localTableName": "public.program_history",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.programs",
+          "updateRule": "cascade"
+        },
+        "program_history_user_id_foreign": {
+          "constraintName": "program_history_user_id_foreign",
+          "columnNames": [
+            "user_id"
+          ],
+          "localTableName": "public.program_history",
           "referencedColumnNames": [
             "id"
           ],
@@ -4587,6 +4972,73 @@
           ],
           "referencedTableName": "public.places",
           "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "program_id": {
+          "name": "program_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        },
+        "process_id": {
+          "name": "process_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 255,
+          "mappedType": "string"
+        }
+      },
+      "name": "programs_processes",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "programs_processes_pkey",
+          "columnNames": [
+            "program_id",
+            "process_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "programs_processes_program_id_foreign": {
+          "constraintName": "programs_processes_program_id_foreign",
+          "columnNames": [
+            "program_id"
+          ],
+          "localTableName": "public.programs_processes",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.programs",
+          "updateRule": "cascade"
+        },
+        "programs_processes_process_id_foreign": {
+          "constraintName": "programs_processes_process_id_foreign",
+          "columnNames": [
+            "process_id"
+          ],
+          "localTableName": "public.programs_processes",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.processes",
           "updateRule": "cascade"
         }
       },

--- a/apps/api/src/db/migrations/Migration20260413182904.ts
+++ b/apps/api/src/db/migrations/Migration20260413182904.ts
@@ -1,0 +1,75 @@
+// this file was generated, do not edit unless creating a new migration
+
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20260413182904 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`alter table "categories"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "items"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "materials"
+                 add column "synonyms" jsonb null;`)
+
+    this.addSql(`alter table "orgs"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "places"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "regions"
+                 add column "desc" jsonb null;`)
+
+    this.addSql(`alter table "components"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "tags"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "users"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "variants"
+                 add column "rank" jsonb null;`)
+
+    this.addSql(`alter table "processes"
+                 add column "rank" jsonb null;`)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "categories"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "items"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "materials"
+                 drop column "synonyms";`)
+
+    this.addSql(`alter table "orgs"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "places"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "regions"
+                 drop column "desc";`)
+
+    this.addSql(`alter table "components"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "tags"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "users"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "variants"
+                 drop column "rank";`)
+
+    this.addSql(`alter table "processes"
+                 drop column "rank";`)
+  }
+}

--- a/apps/api/src/db/migrations/Migration20260413191150.ts
+++ b/apps/api/src/db/migrations/Migration20260413191150.ts
@@ -1,0 +1,128 @@
+// this file was generated, do not edit unless creating a new migration
+
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20260413191150 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`create table "programs" (
+                   "id" varchar(255) not null,
+                   "created_at" timestamptz not null default current_timestamp(),
+                   "updated_at" timestamptz not null default current_timestamp(),
+                   "name" jsonb not null,
+                   "desc" jsonb null,
+                   "social" jsonb null,
+                   "instructions" jsonb null,
+                   "status" text check ("status" in ('PLANNED', 'ACTIVE', 'CLOSED')) not null,
+                   "rank" jsonb null,
+                   "region_id" varchar(255) null,
+                   constraint "programs_pkey" primary key ("id")
+                 );`)
+
+    this.addSql(`create table "programs_orgs" (
+                   "program_id" varchar(255) not null,
+                   "org_id" varchar(255) not null,
+                   "role" varchar(255) not null,
+                   constraint "programs_orgs_pkey" primary key ("program_id", "org_id")
+                 );`)
+
+    this.addSql(`create table "programs_tags" (
+                   "program_id" varchar(255) not null,
+                   "tag_id" varchar(255) not null,
+                   "meta" jsonb null,
+                   constraint "programs_tags_pkey" primary key ("program_id", "tag_id")
+                 );`)
+
+    this.addSql(`create table "program_history" (
+                   "program_id" varchar(255) not null,
+                   "datetime" timestamptz not null,
+                   "user_id" varchar(255) not null,
+                   "original" jsonb null,
+                   "changes" jsonb null,
+                   constraint "program_history_pkey" primary key ("program_id", "datetime")
+                 );`)
+
+    this.addSql(`create table "programs_processes" (
+                   "program_id" varchar(255) not null,
+                   "process_id" varchar(255) not null,
+                   constraint "programs_processes_pkey" primary key ("program_id", "process_id")
+                 );`)
+
+    this.addSql(`alter table "programs"
+                 add constraint "programs_region_id_foreign" foreign key ("region_id") references "regions" ("id") on update cascade on delete set null;`)
+
+    this.addSql(`alter table "programs_orgs"
+                 add constraint "programs_orgs_program_id_foreign" foreign key ("program_id") references "programs" ("id") on update cascade;`)
+    this.addSql(`alter table "programs_orgs"
+                 add constraint "programs_orgs_org_id_foreign" foreign key ("org_id") references "orgs" ("id") on update cascade;`)
+
+    this.addSql(`alter table "programs_tags"
+                 add constraint "programs_tags_program_id_foreign" foreign key ("program_id") references "programs" ("id") on update cascade;`)
+    this.addSql(`alter table "programs_tags"
+                 add constraint "programs_tags_tag_id_foreign" foreign key ("tag_id") references "tags" ("id") on update cascade;`)
+
+    this.addSql(`alter table "program_history"
+                 add constraint "program_history_program_id_foreign" foreign key ("program_id") references "programs" ("id") on update cascade;`)
+    this.addSql(`alter table "program_history"
+                 add constraint "program_history_user_id_foreign" foreign key ("user_id") references "users" ("id") on update cascade;`)
+
+    this.addSql(`alter table "programs_processes"
+                 add constraint "programs_processes_program_id_foreign" foreign key ("program_id") references "programs" ("id") on update cascade;`)
+    this.addSql(`alter table "programs_processes"
+                 add constraint "programs_processes_process_id_foreign" foreign key ("process_id") references "processes" ("id") on update cascade;`)
+
+    this.addSql(`alter table "tags"
+                 drop constraint if exists "tags_type_check";`)
+
+    this.addSql(`alter table "tags"
+                 add constraint "tags_type_check" check (
+                   "type" in (
+                     'PLACE',
+                     'ITEM',
+                     'VARIANT',
+                     'COMPONENT',
+                     'PROCESS',
+                     'PROGRAM',
+                     'ORG'
+                   )
+                 );`)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "programs_orgs"
+                 drop constraint "programs_orgs_program_id_foreign";`)
+
+    this.addSql(`alter table "programs_tags"
+                 drop constraint "programs_tags_program_id_foreign";`)
+
+    this.addSql(`alter table "program_history"
+                 drop constraint "program_history_program_id_foreign";`)
+
+    this.addSql(`alter table "programs_processes"
+                 drop constraint "programs_processes_program_id_foreign";`)
+
+    this.addSql(`drop table if exists "programs" cascade;`)
+
+    this.addSql(`drop table if exists "programs_orgs" cascade;`)
+
+    this.addSql(`drop table if exists "programs_tags" cascade;`)
+
+    this.addSql(`drop table if exists "program_history" cascade;`)
+
+    this.addSql(`drop table if exists "programs_processes" cascade;`)
+
+    this.addSql(`alter table "tags"
+                 drop constraint if exists "tags_type_check";`)
+
+    this.addSql(`alter table "tags"
+                 add constraint "tags_type_check" check (
+                   "type" in (
+                     'PLACE',
+                     'ITEM',
+                     'VARIANT',
+                     'COMPONENT',
+                     'PROCESS',
+                     'ORG'
+                   )
+                 );`)
+  }
+}

--- a/apps/api/src/db/seeds/TestProgramSeeder.ts
+++ b/apps/api/src/db/seeds/TestProgramSeeder.ts
@@ -1,0 +1,26 @@
+import type { EntityManager } from '@mikro-orm/core'
+import { Seeder } from '@mikro-orm/seeder'
+
+import { Program, ProgramStatus } from '@src/process/program.entity'
+
+export const PROGRAM_IDS = ['prog1_AAAAAAAAAAAAAAA', 'prog2_BBBBBBBBBBBBBBB']
+
+export class TestProgramSeeder extends Seeder {
+  async run(em: EntityManager): Promise<void> {
+    for (let i = 0; i < PROGRAM_IDS.length; i++) {
+      const programId = PROGRAM_IDS[i]
+      em.create(Program, {
+        id: programId,
+        name: { en: `Program ${i + 1}`, sv: `Program ${i + 1} Svenska` },
+        desc: { en: `Description for program ${i + 1}`, sv: `Beskrivning för program ${i + 1}` },
+        status: ProgramStatus.ACTIVE,
+        social: {},
+        instructions: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+    }
+
+    await em.flush()
+  }
+}

--- a/apps/api/src/geo/place.entity.ts
+++ b/apps/api/src/geo/place.entity.ts
@@ -13,7 +13,7 @@ import {
 import type { Ref } from '@mikro-orm/core'
 
 import type { TranslatedField } from '@src/common/i18n'
-import { type JSONObject } from '@src/common/z.schema'
+import { type JSONObject, type Rank } from '@src/common/z.schema'
 import { CreatedUpdated } from '@src/db/base.entity'
 import { Point, PointType } from '@src/db/custom.types'
 import { Process } from '@src/process/process.entity'
@@ -44,6 +44,9 @@ export class Place extends CreatedUpdated {
 
   @Property({ type: 'json' })
   osm?: {}
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => Tag, pivotEntity: () => PlacesTag })
   tags = new Collection<Tag>(this)

--- a/apps/api/src/geo/region.entity.ts
+++ b/apps/api/src/geo/region.entity.ts
@@ -18,6 +18,7 @@ import { IDCreatedUpdated } from '@src/db/base.entity'
 import { MultiPolygon, MultiPolygonType } from '@src/db/custom.types'
 import { Component } from '@src/process/component.entity'
 import { Process } from '@src/process/process.entity'
+import { Program } from '@src/process/program.entity'
 import { Variant } from '@src/product/variant.entity'
 import { User } from '@src/users/users.entity'
 
@@ -61,6 +62,9 @@ export class Region extends IDCreatedUpdated {
 
   @OneToMany({ mappedBy: 'region' })
   processes = new Collection<Process>(this)
+
+  @OneToMany({ mappedBy: 'region' })
+  programs = new Collection<Program>(this)
 
   @OneToMany({ mappedBy: 'region' })
   history = new Collection<RegionHistory>(this)

--- a/apps/api/src/geo/region.entity.ts
+++ b/apps/api/src/geo/region.entity.ts
@@ -38,6 +38,9 @@ export class Region extends IDCreatedUpdated {
   @Property({ type: 'json' })
   name!: TranslatedField
 
+  @Property({ type: 'json' })
+  desc?: TranslatedField
+
   @Property({ type: MultiPolygonType })
   geo?: MultiPolygon
 

--- a/apps/api/src/geo/region.model.ts
+++ b/apps/api/src/geo/region.model.ts
@@ -14,6 +14,9 @@ export class Region extends CreatedUpdated {
   @Field(() => String, { nullable: true })
   name?: string
 
+  @Field(() => String, { nullable: true })
+  desc?: string
+
   @Field(() => String, {
     description: 'The type of geographic entity (e.g. country, region, locality)',
   })

--- a/apps/api/src/geo/region.schema.ts
+++ b/apps/api/src/geo/region.schema.ts
@@ -16,6 +16,7 @@ export class RegionSchemaService {
       model.createdAt = DateTime.fromJSDate(entity.createdAt)
       model.updatedAt = DateTime.fromJSDate(entity.updatedAt)
       model.name = input.i18n.tr(entity.name)
+      model.desc = input.i18n.tr(entity.desc)
       model.placetype = entity.placetype
       if (entity.properties && entity.properties['geom:bbox']) {
         model.bbox = entity.properties['geom:bbox'].split(',').map(Number)

--- a/apps/api/src/process/component.entity.ts
+++ b/apps/api/src/process/component.entity.ts
@@ -14,7 +14,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import type { TranslatedField } from '@src/common/i18n'
-import { type JSONObject } from '@src/common/z.schema'
+import { type JSONObject, type Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Material } from '@src/process/material.entity'
@@ -96,6 +96,9 @@ export class Component extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   physical?: ComponentPhysical
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({
     entity: () => Material,

--- a/apps/api/src/process/material.entity.ts
+++ b/apps/api/src/process/material.entity.ts
@@ -46,6 +46,15 @@ export const MaterialShapeSchema = z
 
 export type MaterialShape = z.infer<typeof MaterialShapeSchema>
 
+export const MaterialSynonymsSchema = z.record(
+  z.string(),
+  z.object({
+    abbrev: z.array(z.string()).optional(),
+    full: z.array(z.string()).optional(),
+  }),
+)
+export type MaterialSynonyms = z.infer<typeof MaterialSynonymsSchema>
+
 @Entity({ tableName: 'materials', schema: 'public' })
 export class Material extends IDCreatedUpdated {
   @Property({ type: 'json' })
@@ -53,6 +62,9 @@ export class Material extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   desc?: TranslatedField
+
+  @Property({ type: 'json' })
+  synonyms?: MaterialSynonyms
 
   @Property({ type: 'json' })
   source!: JsonLdDocument

--- a/apps/api/src/process/material.model.ts
+++ b/apps/api/src/process/material.model.ts
@@ -30,6 +30,9 @@ export class Material extends CreatedUpdated implements Named {
   @MaxLength(100_000)
   desc?: string
 
+  @Field(() => [String], { nullable: true })
+  synonyms?: string[]
+
   @Field(() => Boolean, {
     description: 'If true, this is an internal technical classification not shown to end-users',
   })

--- a/apps/api/src/process/material.schema.ts
+++ b/apps/api/src/process/material.schema.ts
@@ -17,6 +17,12 @@ export class MaterialSchemaService {
       model.updatedAt = DateTime.fromJSDate(entity.updatedAt)
       model.name = input.i18n.tr(entity.name)
       model.desc = input.i18n.tr(entity.desc)
+
+      const synonymData = input.i18n.pick(entity.synonyms)
+      if (typeof synonymData === 'object' && synonymData !== null) {
+        model.synonyms = [...(synonymData.abbrev || []), ...(synonymData.full || [])]
+      }
+
       model.technical = entity.technical
       model.shape = entity.shape
       return model

--- a/apps/api/src/process/process.entity.ts
+++ b/apps/api/src/process/process.entity.ts
@@ -15,6 +15,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import type { TranslatedField } from '@src/common/i18n'
+import type { Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Region } from '@src/geo/region.entity'
@@ -230,6 +231,9 @@ export class Process extends IDCreatedUpdated {
   // Rules for matching materials/variants to this process.
   @Property({ type: 'json' })
   rules?: ProcessRules
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => Source, pivotEntity: () => ProcessSources })
   sources = new Collection<Source>(this)

--- a/apps/api/src/process/process.entity.ts
+++ b/apps/api/src/process/process.entity.ts
@@ -20,6 +20,7 @@ import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Region } from '@src/geo/region.entity'
 import { Material } from '@src/process/material.entity'
+import { Program } from '@src/process/program.entity'
 import { Variant } from '@src/product/variant.entity'
 import { Org } from '@src/users/org.entity'
 import { User } from '@src/users/users.entity'
@@ -240,6 +241,9 @@ export class Process extends IDCreatedUpdated {
 
   @OneToMany(() => ProcessSources, (pr) => pr.process)
   processSources = new Collection<ProcessSources>(this)
+
+  @ManyToMany({ entity: () => Program, mappedBy: 'processes' })
+  programs = new Collection<Program>(this)
 
   @ManyToOne()
   org?: Ref<Org>

--- a/apps/api/src/process/process.module.ts
+++ b/apps/api/src/process/process.module.ts
@@ -15,6 +15,9 @@ import { MaterialService } from '@src/process/material.service'
 import { ProcessHistoryResolver, ProcessResolver } from '@src/process/process.resolver'
 import { ProcessSchemaService } from '@src/process/process.schema'
 import { ProcessService } from '@src/process/process.service'
+import { ProgramResolver } from '@src/process/program.resolver'
+import { ProgramSchemaService } from '@src/process/program.schema'
+import { ProgramService } from '@src/process/program.service'
 import { StreamService } from '@src/process/stream.service'
 import { TagResolver } from '@src/process/tag.resolver'
 import { TagSchemaService } from '@src/process/tag.schema'
@@ -46,6 +49,9 @@ import { UsersModule } from '@src/users/users.module'
     ProcessService,
     ProcessSchemaService,
     ProcessHistoryResolver,
+    ProgramResolver,
+    ProgramService,
+    ProgramSchemaService,
     TagResolver,
     TagService,
     TagSchemaService,
@@ -60,6 +66,8 @@ import { UsersModule } from '@src/users/users.module'
     ComponentSchemaService,
     ProcessService,
     ProcessSchemaService,
+    ProgramService,
+    ProgramSchemaService,
     MaterialService,
     MaterialSchemaService,
   ],

--- a/apps/api/src/process/program.entity.ts
+++ b/apps/api/src/process/program.entity.ts
@@ -1,0 +1,130 @@
+import {
+  BaseEntity,
+  Collection,
+  Entity,
+  Enum,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+} from '@mikro-orm/core'
+import type { Ref } from '@mikro-orm/core'
+
+import type { TranslatedField } from '@src/common/i18n'
+import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { IDCreatedUpdated } from '@src/db/base.entity'
+import { Region } from '@src/geo/region.entity'
+import { Process } from '@src/process/process.entity'
+import { Tag } from '@src/process/tag.entity'
+import { Org } from '@src/users/org.entity'
+import { User } from '@src/users/users.entity'
+
+export enum ProgramStatus {
+  PLANNED = 'PLANNED',
+  ACTIVE = 'ACTIVE',
+  CLOSED = 'CLOSED',
+}
+
+@Entity({ tableName: 'programs', schema: 'public' })
+export class Program extends IDCreatedUpdated {
+  @Property({ type: 'json' })
+  name!: TranslatedField
+
+  @Property({ type: 'json' })
+  desc?: TranslatedField
+
+  @Property({ type: 'json' })
+  social?: JSONObject
+
+  @Property({ type: 'json' })
+  instructions?: JSONObject
+
+  @Enum(() => ProgramStatus)
+  status!: ProgramStatus
+
+  @Property({ type: 'json' })
+  rank?: Rank
+
+  @ManyToOne()
+  region?: Ref<Region>
+
+  @ManyToMany({ entity: () => Org, pivotEntity: () => ProgramsOrgs })
+  orgs = new Collection<Org>(this)
+
+  @OneToMany(() => ProgramsOrgs, (po) => po.program)
+  programOrgs = new Collection<ProgramsOrgs>(this)
+
+  @ManyToMany({ entity: () => Process, pivotEntity: () => ProgramsProcesses })
+  processes = new Collection<Process>(this)
+
+  @OneToMany(() => ProgramsProcesses, (pp) => pp.program)
+  programProcesses = new Collection<ProgramsProcesses>(this)
+
+  @ManyToMany({ entity: () => Tag, pivotEntity: () => ProgramsTags })
+  tags = new Collection<Tag>(this)
+
+  @OneToMany({
+    entity: () => ProgramsTags,
+    mappedBy: (pt) => pt.program,
+    orphanRemoval: true,
+  })
+  programTags = new Collection<ProgramsTags>(this)
+
+  @OneToMany(() => ProgramHistory, (history) => history.program)
+  history = new Collection<ProgramHistory>(this)
+}
+
+@Entity({ tableName: 'programs_orgs', schema: 'public' })
+export class ProgramsOrgs extends BaseEntity {
+  @ManyToOne({ primary: true })
+  program!: Program
+
+  @ManyToOne({ primary: true })
+  org!: Org & {}
+
+  @Property()
+  role!: string
+}
+
+@Entity({ tableName: 'programs_processes', schema: 'public' })
+export class ProgramsProcesses extends BaseEntity {
+  @ManyToOne({ primary: true })
+  program!: Program
+
+  @ManyToOne({ primary: true })
+  process!: Process & {}
+}
+
+@Entity({ tableName: 'programs_tags', schema: 'public' })
+export class ProgramsTags extends BaseEntity {
+  @ManyToOne({ primary: true })
+  program!: Program
+
+  @ManyToOne({ primary: true })
+  tag!: Tag & {}
+
+  @Property({ type: 'json' })
+  meta?: Record<string, any>
+}
+
+@Entity({ tableName: 'program_history', schema: 'public' })
+export class ProgramHistory extends BaseEntity {
+  @ManyToOne({ primary: true })
+  program!: Program
+
+  @PrimaryKey()
+  datetime!: Date;
+
+  [PrimaryKeyProp]?: ['program', 'datetime']
+
+  @ManyToOne()
+  user!: Ref<User>
+
+  @Property({ type: 'json' })
+  original?: JSONObject
+
+  @Property({ type: 'json' })
+  changes?: JSONObject
+}

--- a/apps/api/src/process/program.model.ts
+++ b/apps/api/src/process/program.model.ts
@@ -1,0 +1,251 @@
+import { ArgsType, Field, ID, InputType, ObjectType } from '@nestjs/graphql'
+import { JSONObjectResolver } from 'graphql-scalars'
+import { DateTime } from 'luxon'
+
+import { ChangeInputWithLang } from '@src/changes/change-ext.model'
+import { Change } from '@src/changes/change.model'
+import { LuxonDateTimeResolver } from '@src/common/datetime.model'
+import { type JSONObject } from '@src/common/z.schema'
+import { Region } from '@src/geo/region.model'
+import {
+  BaseModel,
+  IDCreatedUpdated,
+  type ModelRef,
+  registerModel,
+  TranslatedInput,
+} from '@src/graphql/base.model'
+import { Named } from '@src/graphql/interfaces.model'
+import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { ProcessPage } from '@src/process/process.model'
+import { ProgramStatus } from '@src/process/program.entity'
+import { TagPage } from '@src/process/tag.model'
+import { OrgsPage } from '@src/users/org.model'
+import { User as UserEntity } from '@src/users/users.entity'
+import { User } from '@src/users/users.model'
+
+@ObjectType({
+  implements: () => [Named],
+  description: 'An administrative description of circular economy processes',
+})
+export class Program extends IDCreatedUpdated implements Named {
+  @Field(() => String)
+  name!: string
+
+  @Field(() => String, { nullable: true })
+  desc?: string
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  social?: JSONObject
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  instructions?: JSONObject
+
+  @Field(() => String)
+  status!: ProgramStatus
+
+  @Field(() => Region, { nullable: true })
+  region?: Region & {}
+
+  @Field(() => OrgsPage, { description: 'Organizations involved in this program' })
+  orgs!: OrgsPage & {}
+
+  @Field(() => ProcessPage, { description: 'Processes run by this program' })
+  processes!: ProcessPage & {}
+
+  @Field(() => TagPage, { description: 'Metadata tags applied to this program' })
+  tags!: TagPage & {}
+
+  @Field(() => ProgramHistoryPage, { description: 'Audit history of changes to this program' })
+  history!: ProgramHistoryPage & {}
+}
+registerModel('Program', Program)
+
+@ObjectType()
+export class ProgramHistory extends BaseModel {
+  @Field(() => Program)
+  program!: Program
+
+  @Field(() => LuxonDateTimeResolver)
+  datetime!: DateTime
+
+  @Field(() => User)
+  user!: ModelRef<User, UserEntity>
+
+  @Field(() => Program, { nullable: true })
+  original?: Program
+
+  @Field(() => Program, { nullable: true })
+  changes?: Program
+}
+
+@ObjectType()
+export class ProgramHistoryPage extends Paginated(ProgramHistory) {}
+
+@ObjectType()
+export class ProgramsPage extends Paginated(Program) {}
+
+@ArgsType()
+export class ProgramHistoryArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class ProgramsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class ProgramOrgsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class ProgramProcessesArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class ProgramTagsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@InputType()
+export class ProgramOrgsInput {
+  @Field(() => ID)
+  id!: string
+
+  @Field(() => String, { nullable: true })
+  role?: string
+}
+
+@InputType()
+export class ProgramProcessesInput {
+  @Field(() => ID)
+  id!: string
+}
+
+@InputType()
+export class ProgramTagsInput {
+  @Field(() => ID)
+  id!: string
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  meta?: JSONObject
+}
+
+@InputType()
+export class CreateProgramInput extends ChangeInputWithLang {
+  @Field(() => String, { nullable: true })
+  name?: string
+
+  @Field(() => [TranslatedInput], { nullable: true })
+  nameTr?: TranslatedInput[]
+
+  @Field(() => String, { nullable: true })
+  desc?: string
+
+  @Field(() => [TranslatedInput], { nullable: true })
+  descTr?: TranslatedInput[]
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  social?: JSONObject
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  instructions?: JSONObject
+
+  @Field(() => String)
+  status!: ProgramStatus
+
+  @Field(() => ID, { nullable: true })
+  region?: string
+
+  @Field(() => [ProgramOrgsInput], { nullable: true })
+  orgs?: ProgramOrgsInput[]
+
+  @Field(() => [ProgramProcessesInput], { nullable: true })
+  processes?: ProgramProcessesInput[]
+
+  @Field(() => [ProgramTagsInput], { nullable: true })
+  tags?: ProgramTagsInput[]
+}
+
+@InputType()
+export class UpdateProgramInput extends ChangeInputWithLang {
+  @Field(() => ID)
+  id!: string
+
+  @Field(() => String, { nullable: true })
+  name?: string
+
+  @Field(() => [TranslatedInput], { nullable: true })
+  nameTr?: TranslatedInput[]
+
+  @Field(() => String, { nullable: true })
+  desc?: string
+
+  @Field(() => [TranslatedInput], { nullable: true })
+  descTr?: TranslatedInput[]
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  social?: JSONObject
+
+  @Field(() => JSONObjectResolver, { nullable: true })
+  instructions?: JSONObject
+
+  @Field(() => String, { nullable: true })
+  status?: ProgramStatus
+
+  @Field(() => ID, { nullable: true })
+  region?: string
+
+  @Field(() => [ProgramOrgsInput], { nullable: true })
+  orgs?: ProgramOrgsInput[]
+
+  @Field(() => [ProgramOrgsInput], { nullable: true })
+  addOrgs?: ProgramOrgsInput[]
+
+  @Field(() => [ID], { nullable: true })
+  removeOrgs?: string[]
+
+  @Field(() => [ProgramProcessesInput], { nullable: true })
+  processes?: ProgramProcessesInput[]
+
+  @Field(() => [ProgramProcessesInput], { nullable: true })
+  addProcesses?: ProgramProcessesInput[]
+
+  @Field(() => [ID], { nullable: true })
+  removeProcesses?: string[]
+
+  @Field(() => [ProgramTagsInput], { nullable: true })
+  tags?: ProgramTagsInput[]
+
+  @Field(() => [ProgramTagsInput], { nullable: true })
+  addTags?: ProgramTagsInput[]
+
+  @Field(() => [ID], { nullable: true })
+  removeTags?: string[]
+}
+
+@ObjectType()
+export class CreateProgramOutput {
+  @Field(() => Change, { nullable: true })
+  change?: Change & {}
+
+  @Field(() => Program, { nullable: true })
+  program?: Program
+}
+
+@ObjectType()
+export class UpdateProgramOutput {
+  @Field(() => Change, { nullable: true })
+  change?: Change & {}
+
+  @Field(() => Program, { nullable: true })
+  program?: Program
+
+  @Field(() => Program, {
+    nullable: true,
+    description: 'The program as currently persisted in the database',
+  })
+  currentProgram?: Program & {}
+}

--- a/apps/api/src/process/program.resolver.spec.ts
+++ b/apps/api/src/process/program.resolver.spec.ts
@@ -1,0 +1,127 @@
+import { MikroORM } from '@mikro-orm/postgresql'
+import { INestApplication } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { AppTestModule } from '@test/app-test.module'
+import { graphql } from '@test/gql'
+import { GraphQLTestClient } from '@test/graphql.utils'
+
+import { BaseSeeder } from '@src/db/seeds/BaseSeeder'
+import { PROGRAM_IDS, TestProgramSeeder } from '@src/db/seeds/TestProgramSeeder'
+import { UserSeeder } from '@src/db/seeds/UserSeeder'
+import { clearDatabase } from '@src/db/test.utils'
+import { WindmillMockService } from '@src/windmill/windmill.mock.service'
+import { WindmillService } from '@src/windmill/windmill.service'
+
+describe('ProgramResolver (integration)', () => {
+  let app: INestApplication
+  let gql: GraphQLTestClient
+  let programID: string
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppTestModule],
+    })
+      .overrideProvider(WindmillService)
+      .useClass(WindmillMockService)
+      .compile()
+
+    app = module.createNestApplication()
+    await app.init()
+
+    gql = new GraphQLTestClient(app)
+
+    const orm = module.get<MikroORM>(MikroORM)
+
+    await clearDatabase(orm, 'public', ['users'])
+    await orm.seeder.seed(BaseSeeder, UserSeeder, TestProgramSeeder)
+
+    await gql.signIn('admin', 'password')
+
+    programID = PROGRAM_IDS[0]
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  test('should query programs with pagination', async () => {
+    const res = await gql.send(
+      graphql(`
+        query ProgramResolverListPrograms($first: Int) {
+          programs(first: $first) {
+            nodes {
+              id
+              name
+            }
+            totalCount
+          }
+        }
+      `),
+      { first: 10 },
+    )
+    expect(res.data?.programs.nodes?.length).toBeGreaterThan(0)
+    expect(res.data?.programs.totalCount).toBeGreaterThan(0)
+  })
+
+  test('should query a single program', async () => {
+    const res = await gql.send(
+      graphql(`
+        query ProgramResolverGetProgram($id: ID!) {
+          program(id: $id) {
+            id
+            name
+          }
+        }
+      `),
+      { id: programID },
+    )
+    expect(res.data?.program).toBeDefined()
+    expect(res.data?.program?.id).toBe(programID)
+  })
+
+  test('should create a program', async () => {
+    const res = await gql.send(
+      graphql(`
+        mutation ProgramResolverCreateProgram($input: CreateProgramInput!) {
+          createProgram(input: $input) {
+            program {
+              id
+              name
+              status
+            }
+          }
+        }
+      `),
+      {
+        input: {
+          nameTr: [{ lang: 'en', text: 'New Program' }],
+          status: 'ACTIVE',
+        },
+      },
+    )
+    expect(res.data?.createProgram.program).toBeDefined()
+    expect(res.data?.createProgram.program.name).toBe('New Program')
+  })
+
+  test('should update a program', async () => {
+    const res = await gql.send(
+      graphql(`
+        mutation ProgramResolverUpdateProgram($input: UpdateProgramInput!) {
+          updateProgram(input: $input) {
+            program {
+              id
+              name
+            }
+          }
+        }
+      `),
+      {
+        input: {
+          id: programID,
+          nameTr: [{ lang: 'en', text: 'Updated Program Name' }],
+        },
+      },
+    )
+    expect(res.data?.updateProgram.program.name).toBe('Updated Program Name')
+  })
+})

--- a/apps/api/src/process/program.resolver.ts
+++ b/apps/api/src/process/program.resolver.ts
@@ -1,0 +1,140 @@
+import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
+
+import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
+import { OptionalAuth } from '@src/auth/decorators'
+import { Change } from '@src/changes/change.model'
+import { EditService } from '@src/changes/edit.service'
+import { NotFoundErr } from '@src/common/exceptions'
+import { TransformService } from '@src/common/transform'
+import { ModelEditSchema } from '@src/graphql/base.model'
+import { Process, ProcessPage } from '@src/process/process.model'
+import {
+  CreateProgramInput,
+  CreateProgramOutput,
+  Program,
+  ProgramHistory,
+  ProgramHistoryArgs,
+  ProgramHistoryPage,
+  ProgramOrgsArgs,
+  ProgramProcessesArgs,
+  ProgramsArgs,
+  ProgramsPage,
+  ProgramTagsArgs,
+  UpdateProgramInput,
+  UpdateProgramOutput,
+} from '@src/process/program.model'
+import { ProgramSchemaService } from '@src/process/program.schema'
+import { ProgramService } from '@src/process/program.service'
+import { Tag, TagPage } from '@src/process/tag.model'
+import { Org, OrgsPage } from '@src/users/org.model'
+
+@Resolver(() => Program)
+export class ProgramResolver {
+  constructor(
+    private readonly programService: ProgramService,
+    private readonly transform: TransformService,
+    private readonly programSchemaService: ProgramSchemaService,
+    private readonly editService: EditService,
+  ) {}
+
+  @Query(() => ProgramsPage, { name: 'programs' })
+  @OptionalAuth()
+  async programs(@Args() args: ProgramsArgs): Promise<ProgramsPage> {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(ProgramsArgs, args)
+    const cursor = await this.programService.find(filter)
+    return this.transform.entityToPaginated(Program, ProgramsPage, cursor, parsedArgs)
+  }
+
+  @Query(() => Program, { name: 'program', nullable: true })
+  @OptionalAuth()
+  async program(@Args('id', { type: () => ID }) id: string): Promise<Program> {
+    const program = await this.programService.findOneByID(id)
+    if (!program) {
+      throw NotFoundErr('Program not found')
+    }
+    const result = await this.transform.entityToModel(Program, program)
+    return result
+  }
+
+  @Query(() => ModelEditSchema, { nullable: true })
+  @OptionalAuth()
+  async programSchema(): Promise<ModelEditSchema> {
+    return {
+      create: {
+        schema: this.programSchemaService.CreateJSONSchema,
+        uischema: this.programSchemaService.CreateUISchema,
+      },
+      update: {
+        schema: this.programSchemaService.UpdateJSONSchema,
+        uischema: this.programSchemaService.UpdateUISchema,
+      },
+    }
+  }
+
+  @ResolveField()
+  async orgs(@Parent() program: Program, @Args() args: ProgramOrgsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(ProgramOrgsArgs, args)
+    const cursor = await this.programService.orgs(program.id, filter)
+    return this.transform.entityToPaginated(Org, OrgsPage, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async processes(@Parent() program: Program, @Args() args: ProgramProcessesArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(ProgramProcessesArgs, args)
+    const cursor = await this.programService.processes(program.id, filter)
+    return this.transform.entityToPaginated(Process, ProcessPage, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async tags(@Parent() program: Program, @Args() args: ProgramTagsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(ProgramTagsArgs, args)
+    const cursor = await this.programService.tags(program.id, filter)
+    return this.transform.entityToPaginated(Tag, TagPage, cursor, parsedArgs)
+  }
+
+  @ResolveField(() => ProgramHistoryPage)
+  async history(@Parent() program: Program, @Args() args: ProgramHistoryArgs) {
+    const [, filter] = await this.transform.paginationArgs(ProgramHistoryArgs, args)
+    const cursor = await this.programService.history(program.id, filter)
+    const items = await Promise.all(
+      cursor.items.map((h: any) => this.transform.entityToModel(ProgramHistory, h)),
+    )
+    return this.transform.objectsToPaginated(
+      ProgramHistoryPage,
+      { items, count: cursor.count },
+      true,
+    )
+  }
+
+  @Mutation(() => CreateProgramOutput, { name: 'createProgram', nullable: true })
+  async createProgram(
+    @Args('input') input: CreateProgramInput,
+    @AuthUser() user: ReqUser,
+  ): Promise<CreateProgramOutput> {
+    input = await this.programSchemaService.parseCreateInput(input)
+    const { program, change } = await this.programService.create(input, user.id)
+    const model = await this.transform.entityToModel(Program, program)
+    return {
+      program: model,
+      change: change ? await this.transform.entityToModel(Change, change) : undefined,
+    }
+  }
+
+  @Mutation(() => UpdateProgramOutput, { name: 'updateProgram', nullable: true })
+  async updateProgram(
+    @Args('input') input: UpdateProgramInput,
+    @AuthUser() user: ReqUser,
+  ): Promise<UpdateProgramOutput> {
+    input = await this.programSchemaService.parseUpdateInput(input)
+    const { program, change, currentProgram } = await this.programService.update(input, user.id)
+    const model = await this.transform.entityToModel(Program, program)
+    const currentModel = currentProgram
+      ? await this.transform.entityToModel(Program, currentProgram)
+      : undefined
+    return {
+      program: model,
+      currentProgram: currentModel,
+      change: change ? await this.transform.entityToModel(Change, change) : undefined,
+    }
+  }
+}

--- a/apps/api/src/process/program.schema.ts
+++ b/apps/api/src/process/program.schema.ts
@@ -1,0 +1,327 @@
+import { BaseEntity } from '@mikro-orm/core'
+import { Injectable } from '@nestjs/common'
+import { ValidateFunction } from 'ajv'
+import { DateTime } from 'luxon'
+import { z } from 'zod/v4'
+
+import { ChangeInputWithLangSchema } from '@src/changes/change.schema'
+import { BaseSchemaService, RelMetaSchema, zToSchema } from '@src/common/base.schema'
+import { TrArraySchema } from '@src/common/i18n'
+import { I18nService } from '@src/common/i18n.service'
+import { ISchemaService, IsSchemaService } from '@src/common/meta.service'
+import { UISchemaElement } from '@src/common/ui.schema'
+import { TransformInput, ZService } from '@src/common/z.service'
+import { RegionIDSchema } from '@src/geo/region.model'
+import { ProcessIDSchema } from '@src/process/process.schema'
+import {
+  Program as ProgramEntity,
+  ProgramHistory as ProgramHistoryEntity,
+  ProgramStatus,
+} from '@src/process/program.entity'
+import {
+  CreateProgramInput,
+  Program,
+  ProgramHistory,
+  UpdateProgramInput,
+} from '@src/process/program.model'
+import { TagDefinitionIDSchema } from '@src/process/tag.model'
+import { OrgIDSchema } from '@src/users/org.schema'
+import { User } from '@src/users/users.model'
+
+export const ProgramIDSchema = z.string().meta({
+  id: 'Program',
+  name: 'Program ID',
+})
+
+@Injectable()
+@IsSchemaService(ProgramEntity)
+export class ProgramSchemaService implements ISchemaService {
+  OutputModel = Program
+  CreateInputModel = CreateProgramInput
+  UpdateInputModel = UpdateProgramInput
+
+  ProgramOrgsInputSchema
+  ProgramProcessesInputSchema
+  ProgramTagsInputSchema
+  CreateSchema
+  CreateJSONSchema: z.core.JSONSchema.BaseSchema
+  CreateValidator: ValidateFunction
+  CreateUISchema: UISchemaElement
+  UpdateSchema
+  UpdateJSONSchema: z.core.JSONSchema.BaseSchema
+  UpdateValidator: ValidateFunction
+  UpdateUISchema: UISchemaElement
+
+  constructor(
+    private readonly i18n: I18nService,
+    private readonly baseSchema: BaseSchemaService,
+    private readonly zService: ZService,
+  ) {
+    const ProgramTransform = z.transform((input: TransformInput) => {
+      const entity = input.input as ProgramEntity
+      const model = new Program()
+      model.id = entity.id
+      model.createdAt = DateTime.fromJSDate(entity.createdAt)
+      model.updatedAt = DateTime.fromJSDate(entity.updatedAt)
+      model.name = input.i18n.tr(entity.name) as string
+      model.desc = input.i18n.tr(entity.desc)
+      model.social = entity.social
+      model.instructions = entity.instructions
+      model.status = entity.status
+      return model
+    })
+    this.zService.registerEntityTransform(ProgramEntity, Program, ProgramTransform)
+
+    const ProgramHistoryTransform = z.transform((input: TransformInput) => {
+      const entity = input.input as ProgramHistoryEntity
+      const model = new ProgramHistory()
+      model.datetime = DateTime.fromJSDate(entity.datetime)
+      model.user = entity.user as unknown as User & {}
+      model.original = entity.original as Program | undefined
+      model.changes = entity.changes as Program | undefined
+      return model
+    })
+    this.zService.registerEntityTransform(
+      ProgramHistoryEntity,
+      ProgramHistory,
+      ProgramHistoryTransform,
+    )
+
+    this.ProgramOrgsInputSchema = z.strictObject({
+      id: OrgIDSchema,
+      role: z.string().optional(),
+    })
+    this.ProgramProcessesInputSchema = z.strictObject({
+      id: ProcessIDSchema,
+    })
+    this.ProgramTagsInputSchema = z.strictObject({
+      id: TagDefinitionIDSchema,
+      meta: RelMetaSchema,
+    })
+
+    this.CreateSchema = ChangeInputWithLangSchema.extend({
+      name: z.string().min(1).max(1024).optional(),
+      nameTr: TrArraySchema,
+      desc: z.string().max(100_000).optional(),
+      descTr: TrArraySchema,
+      social: z.record(z.string(), z.any()).optional(),
+      instructions: z.record(z.string(), z.any()).optional(),
+      status: z.nativeEnum(ProgramStatus).default(ProgramStatus.ACTIVE),
+      region: RegionIDSchema.optional(),
+      orgs: z.array(this.ProgramOrgsInputSchema).optional(),
+      processes: z.array(this.ProgramProcessesInputSchema).optional(),
+      tags: z.array(this.ProgramTagsInputSchema).optional(),
+    })
+
+    this.CreateJSONSchema = zToSchema(this.CreateSchema)
+    this.CreateUISchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/nameTr',
+          label: 'Name Translations',
+          options: this.baseSchema.trOptionsUISchema(),
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/descTr',
+          label: 'Description Translations',
+          options: this.baseSchema.trOptionsUISchema(),
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/status',
+          label: 'Status',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/region',
+          label: 'Region',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/orgs',
+          label: 'Organizations',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/processes',
+          label: 'Processes',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/tags',
+          label: 'Tags',
+        },
+      ],
+    }
+
+    this.UpdateSchema = ChangeInputWithLangSchema.extend({
+      id: ProgramIDSchema,
+      name: z.string().min(1).max(1024).optional(),
+      nameTr: TrArraySchema.optional(),
+      desc: z.string().max(100_000).optional(),
+      descTr: TrArraySchema.optional(),
+      social: z.record(z.string(), z.any()).optional(),
+      instructions: z.record(z.string(), z.any()).optional(),
+      status: z.enum(ProgramStatus).optional(),
+      region: RegionIDSchema.optional(),
+      orgs: z.array(this.ProgramOrgsInputSchema).optional(),
+      addOrgs: z.array(this.ProgramOrgsInputSchema).optional(),
+      removeOrgs: z.array(z.string()).optional(),
+      processes: z.array(this.ProgramProcessesInputSchema).optional(),
+      addProcesses: z.array(this.ProgramProcessesInputSchema).optional(),
+      removeProcesses: z.array(z.string()).optional(),
+      tags: z.array(this.ProgramTagsInputSchema).optional(),
+      addTags: z.array(this.ProgramTagsInputSchema).optional(),
+      removeTags: z.array(z.string()).optional(),
+    })
+    this.UpdateJSONSchema = zToSchema(this.UpdateSchema)
+    this.UpdateUISchema = {
+      type: 'VerticalLayout',
+      elements: [
+        {
+          type: 'Control',
+          scope: '#/properties/nameTr',
+          label: 'Name Translations',
+          options: this.baseSchema.trOptionsUISchema(),
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/descTr',
+          label: 'Description Translations',
+          options: this.baseSchema.trOptionsUISchema(),
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/status',
+          label: 'Status',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/region',
+          label: 'Region',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/orgs',
+          label: 'Organizations',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/addOrgs',
+          label: 'Add Organizations',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/removeOrgs',
+          label: 'Remove Organizations',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/processes',
+          label: 'Processes',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/addProcesses',
+          label: 'Add Processes',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/removeProcesses',
+          label: 'Remove Processes',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/tags',
+          label: 'Tags',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/addTags',
+          label: 'Add Tags',
+        },
+        {
+          type: 'Control',
+          scope: '#/properties/removeTags',
+          label: 'Remove Tags',
+        },
+      ],
+    }
+    this.CreateValidator = this.baseSchema.ajv.compile(this.CreateJSONSchema)
+    this.UpdateValidator = this.baseSchema.ajv.compile(this.UpdateJSONSchema)
+  }
+
+  async parseCreateInput(input: any) {
+    return this.zService.parse(this.CreateSchema, input)
+  }
+
+  async parseUpdateInput(input: any) {
+    return this.zService.parse(this.UpdateSchema, input)
+  }
+
+  async createInputModel<E extends BaseEntity>(entity: E): Promise<any> {
+    const e = entity as any
+    const data: Record<string, any> = {
+      status: e.status,
+      social: e.social,
+      instructions: e.instructions,
+    }
+    this.baseSchema.applyTranslatedField(data, e.name, 'name', 'nameTr')
+    this.baseSchema.applyTranslatedField(data, e.desc, 'desc', 'descTr')
+    data.orgs = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programOrgs),
+      'program',
+      'org',
+    )
+    data.processes = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programProcesses),
+      'program',
+      'process',
+    )
+    data.tags = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programTags),
+      'program',
+      'tag',
+    )
+    if (e.region?.id) {
+      data.region = e.region.id
+    }
+    this.CreateValidator(data)
+    return this.zService.parse(this.CreateSchema, data as any)
+  }
+
+  async updateInputModel<E extends BaseEntity>(entity: E): Promise<any> {
+    const e = entity as any
+    const data: Record<string, any> = {
+      id: e.id,
+      status: e.status,
+      social: e.social,
+      instructions: e.instructions,
+    }
+    this.baseSchema.applyTranslatedField(data, e.name, 'name', 'nameTr')
+    this.baseSchema.applyTranslatedField(data, e.desc, 'desc', 'descTr')
+    data.orgs = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programOrgs),
+      'program',
+      'org',
+    )
+    data.processes = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programProcesses),
+      'program',
+      'process',
+    )
+    data.tags = this.baseSchema.collectionToInput(
+      this.baseSchema.safeCollectionItems(e.programTags),
+      'program',
+      'tag',
+    )
+    if (e.region?.id) {
+      data.region = e.region.id
+    }
+    this.UpdateValidator(data)
+    return this.zService.parse(this.UpdateSchema, data as any)
+  }
+}

--- a/apps/api/src/process/program.service.ts
+++ b/apps/api/src/process/program.service.ts
@@ -1,0 +1,313 @@
+import { EntityManager } from '@mikro-orm/postgresql'
+import { Injectable } from '@nestjs/common'
+
+import { isUsingChange } from '@src/changes/change-ext.model'
+import { Change } from '@src/changes/change.entity'
+import { EditService } from '@src/changes/edit.service'
+import { mapOrderBy } from '@src/common/db.utils'
+import { I18nService } from '@src/common/i18n.service'
+import { CursorOptions } from '@src/common/transform'
+import { IEntityService, IsEntityService } from '@src/db/base.entity'
+import { Region } from '@src/geo/region.entity'
+import { Process } from '@src/process/process.entity'
+import {
+  Program,
+  ProgramHistory,
+  ProgramsOrgs,
+  ProgramsProcesses,
+  ProgramsTags,
+} from '@src/process/program.entity'
+import { CreateProgramInput, UpdateProgramInput } from '@src/process/program.model'
+import { Tag } from '@src/process/tag.entity'
+import { TagService } from '@src/process/tag.service'
+import { Org } from '@src/users/org.entity'
+
+@Injectable()
+@IsEntityService(Program)
+export class ProgramService implements IEntityService<Program> {
+  constructor(
+    private readonly em: EntityManager,
+    private readonly editService: EditService,
+    private readonly tagService: TagService,
+    private readonly i18n: I18nService,
+  ) {}
+
+  async findOneByID(id: string) {
+    return await this.em.findOne(
+      Program,
+      { id },
+      { populate: ['region', 'programOrgs', 'programProcesses', 'programTags'] },
+    )
+  }
+
+  async findManyByID(ids: string[]) {
+    return this.em.find(
+      Program,
+      { id: { $in: ids } },
+      { populate: ['region', 'programOrgs', 'programProcesses', 'programTags'] },
+    )
+  }
+
+  async find(opts: CursorOptions<Program>) {
+    opts.options.populate = ['region', 'programOrgs', 'programProcesses', 'programTags']
+    const programs = await this.em.find(Program, opts.where, opts.options)
+    const count = await this.em.count(Program, opts.where)
+    return {
+      items: programs,
+      count,
+    }
+  }
+
+  async orgs(programID: string, opts: CursorOptions<Org>) {
+    opts.where.programs = this.em.getReference(Program, programID)
+    const orgs = await this.em.find(Org, opts.where, opts.options)
+    const count = await this.em.count(Org, { programs: opts.where.programs })
+    return {
+      items: orgs,
+      count,
+    }
+  }
+
+  async processes(programID: string, opts: CursorOptions<Process>) {
+    opts.where.programs = this.em.getReference(Program, programID)
+    const processes = await this.em.find(Process, opts.where, opts.options)
+    const count = await this.em.count(Process, { programs: opts.where.programs })
+    return {
+      items: processes,
+      count,
+    }
+  }
+
+  async tagsList(programID: string) {
+    const tagDefs = await this.em.find(Tag, { programs: programID })
+    const tags = await this.em.find(
+      ProgramsTags,
+      { program: programID },
+      {
+        orderBy: { tag: 'ASC' },
+      },
+    )
+    const combinedTags = []
+    for (const tag of tags) {
+      const tagDef = tagDefs.find((t) => t.id === tag.tag.id)
+      if (tagDef) {
+        tagDef.meta = tag.meta
+        combinedTags.push(tagDef)
+      }
+    }
+    return combinedTags
+  }
+
+  async tags(programID: string, opts: CursorOptions<Tag>) {
+    opts.where.programs = this.em.getReference(Program, programID)
+    const tagDefs = await this.em.find(Tag, opts.where, opts.options)
+    const tags = await this.em.find(
+      ProgramsTags,
+      { program: programID },
+      {
+        orderBy: mapOrderBy(opts.options.orderBy, { id: 'tag' }),
+        limit: opts.options.limit,
+      },
+    )
+    const combinedTags = []
+    for (const tag of tags) {
+      const tagDef = tagDefs.find((t) => t.id === tag.tag.id)
+      if (tagDef) {
+        tagDef.meta = tag.meta
+        combinedTags.push(tagDef)
+      }
+    }
+    const count = await this.em.count(ProgramsTags, { program: opts.where.programs })
+    return {
+      items: combinedTags,
+      count,
+    }
+  }
+
+  async create(input: CreateProgramInput, userID: string) {
+    const program = new Program()
+    if (!isUsingChange(input)) {
+      await this.setFields(program, input)
+      await this.editService.createHistory(
+        Program.name,
+        userID,
+        undefined,
+        this.editService.entityToChangePOJO(Program.name, program),
+      )
+      await this.em.persist(program).flush()
+      return { program }
+    }
+    const change = await this.editService.findOneOrCreate(input.changeID, input.change, userID)
+    await this.setFields(program, input, change)
+    await this.editService.createEntityEdit(change, program)
+    await this.editService.persistAndMaybeTriggerReview(change)
+    await this.editService.checkMerge(change, input)
+    return { program, change }
+  }
+
+  async update(input: UpdateProgramInput, userID: string) {
+    const { entity: program, change } = await this.editService.findOneWithChangeInput(
+      input,
+      userID,
+      Program,
+      {
+        id: input.id,
+      },
+      { populate: ['region', 'programOrgs', 'programProcesses', 'programTags'] },
+    )
+    if (!program) {
+      throw new Error('Program not found')
+    }
+    if (!change) {
+      const original = this.editService.entityToChangePOJO(Program.name, program)
+      await this.setFields(program, input)
+      await this.editService.createHistory(
+        Program.name,
+        userID,
+        original,
+        this.editService.entityToChangePOJO(Program.name, program),
+      )
+      await this.em.persist(program).flush()
+      return { program }
+    }
+    await this.editService.beginUpdateEntityEdit(change, program)
+    await this.setFields(program, input, change)
+    await this.editService.updateEntityEdit(change, program)
+    const currentProgram = await this.em.findOne(
+      Program,
+      { id: input.id },
+      { disableIdentityMap: true },
+    )
+    await this.editService.persistAndMaybeTriggerReview(change)
+    await this.editService.checkMerge(change, input)
+    return { program, change, currentProgram: currentProgram ?? undefined }
+  }
+
+  async history(programID: string, opts: CursorOptions<ProgramHistory>) {
+    const items = await this.em.find(
+      ProgramHistory,
+      { program: programID },
+      {
+        populate: ['user'],
+        orderBy: { datetime: 'ASC' },
+        limit: opts.options.limit,
+        offset: opts.options.offset,
+      },
+    )
+    const count = await this.em.count(ProgramHistory, { program: programID })
+    return { items, count }
+  }
+
+  private async setFields(
+    program: Program,
+    input: Partial<CreateProgramInput & UpdateProgramInput>,
+    change?: Change,
+  ) {
+    if (input.name) {
+      program.name = this.i18n.addTrReq(program.name, input.name, input.lang)
+    }
+    if (input.nameTr) {
+      program.name = this.i18n.addTrReq(program.name, input.nameTr, input.lang)
+    }
+    if (input.desc) {
+      program.desc = this.i18n.addTr(program.desc, input.desc, input.lang)
+    }
+    if (input.descTr) {
+      program.desc = this.i18n.addTr(program.desc, input.descTr, input.lang)
+    }
+    if (input.social !== undefined) {
+      program.social = input.social
+    }
+    if (input.instructions !== undefined) {
+      program.instructions = input.instructions
+    }
+    if (input.status !== undefined) {
+      program.status = input.status
+    }
+
+    if (input.region !== undefined) {
+      program.region = input.region
+        ? (this.em.getReference(Region, input.region, { wrapped: true }) as any)
+        : undefined
+    }
+
+    if (input.orgs !== undefined) {
+      program.programOrgs.removeAll()
+      for (const org of input.orgs) {
+        const pOrg = new ProgramsOrgs()
+        pOrg.program = program
+        pOrg.org = this.em.getReference(Org, org.id)
+        if (org.role) pOrg.role = org.role
+        program.programOrgs.add(pOrg)
+      }
+    }
+    if ('addOrgs' in input && input.addOrgs) {
+      for (const org of input.addOrgs) {
+        const pOrg = new ProgramsOrgs()
+        pOrg.program = program
+        pOrg.org = this.em.getReference(Org, org.id)
+        if (org.role) pOrg.role = org.role
+        program.programOrgs.add(pOrg)
+      }
+    }
+    if ('removeOrgs' in input && input.removeOrgs) {
+      for (const po of program.programOrgs) {
+        if (input.removeOrgs.includes(po.org.id)) {
+          program.programOrgs.remove(po)
+        }
+      }
+    }
+
+    if (input.processes !== undefined) {
+      program.programProcesses.removeAll()
+      for (const process of input.processes) {
+        const pProcess = new ProgramsProcesses()
+        pProcess.program = program
+        pProcess.process = this.em.getReference(Process, process.id)
+        program.programProcesses.add(pProcess)
+      }
+    }
+    if ('addProcesses' in input && input.addProcesses) {
+      for (const process of input.addProcesses) {
+        const pProcess = new ProgramsProcesses()
+        pProcess.program = program
+        pProcess.process = this.em.getReference(Process, process.id)
+        program.programProcesses.add(pProcess)
+      }
+    }
+    if ('removeProcesses' in input && input.removeProcesses) {
+      for (const pp of program.programProcesses) {
+        if (input.removeProcesses.includes(pp.process.id)) {
+          program.programProcesses.remove(pp)
+        }
+      }
+    }
+
+    if (input.tags !== undefined) {
+      program.programTags.removeAll()
+      for (const tag of input.tags) {
+        const pTag = new ProgramsTags()
+        pTag.program = program
+        pTag.tag = this.em.getReference(Tag, tag.id)
+        pTag.meta = tag.meta
+        program.programTags.add(pTag)
+      }
+    }
+    if ('addTags' in input && input.addTags) {
+      for (const tag of input.addTags) {
+        const pTag = new ProgramsTags()
+        pTag.program = program
+        pTag.tag = this.em.getReference(Tag, tag.id)
+        pTag.meta = tag.meta
+        program.programTags.add(pTag)
+      }
+    }
+    if ('removeTags' in input && input.removeTags) {
+      for (const pt of program.programTags) {
+        if (input.removeTags.includes(pt.tag.id)) {
+          program.programTags.remove(pt)
+        }
+      }
+    }
+  }
+}

--- a/apps/api/src/process/tag.entity.ts
+++ b/apps/api/src/process/tag.entity.ts
@@ -3,7 +3,7 @@ import { JSONSchemaType } from 'ajv/dist/2020'
 import { z } from 'zod/v4'
 
 import { type TranslatedField } from '@src/common/i18n'
-import { AjvTemplateSchema, JSONType, ZTranslatedField } from '@src/common/z.schema'
+import { AjvTemplateSchema, JSONType, type Rank, ZTranslatedField } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Component } from '@src/process/component.entity'
@@ -92,6 +92,9 @@ export class Tag extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rules?: TagRules
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => Place, mappedBy: 'tags' })
   places = new Collection<Place>(this)

--- a/apps/api/src/process/tag.entity.ts
+++ b/apps/api/src/process/tag.entity.ts
@@ -7,6 +7,7 @@ import { AjvTemplateSchema, JSONType, type Rank, ZTranslatedField } from '@src/c
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Component } from '@src/process/component.entity'
+import { Program } from '@src/process/program.entity'
 import { Item } from '@src/product/item.entity'
 import { Variant } from '@src/product/variant.entity'
 
@@ -16,6 +17,7 @@ export enum TagType {
   VARIANT = 'VARIANT',
   COMPONENT = 'COMPONENT',
   PROCESS = 'PROCESS',
+  PROGRAM = 'PROGRAM',
   ORG = 'ORG',
 }
 
@@ -107,6 +109,9 @@ export class Tag extends IDCreatedUpdated {
 
   @ManyToMany({ entity: () => Component, mappedBy: 'tags' })
   components = new Collection<Component>(this)
+
+  @ManyToMany({ entity: () => Program, mappedBy: 'tags' })
+  programs = new Collection<Program>(this)
 
   meta?: Record<string, any>
 }

--- a/apps/api/src/product/category.entity.ts
+++ b/apps/api/src/product/category.entity.ts
@@ -13,6 +13,7 @@ import {
 import type { Ref } from '@mikro-orm/core'
 
 import type { TranslatedField } from '@src/common/i18n'
+import type { Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Item } from '@src/product/item.entity'
 import { User } from '@src/users/users.entity'
@@ -32,6 +33,9 @@ export class Category extends IDCreatedUpdated {
 
   @Property({ nullable: true })
   imageURL?: string
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @OneToMany({ entity: () => CategoryTree, mappedBy: 'ancestor' })
   ancestors = new Collection<CategoryTree>(this)

--- a/apps/api/src/product/item.entity.ts
+++ b/apps/api/src/product/item.entity.ts
@@ -13,6 +13,7 @@ import {
 import { z } from 'zod/v4'
 
 import { type TranslatedField } from '@src/common/i18n'
+import type { Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Tag } from '@src/process/tag.entity'
 import { Category } from '@src/product/category.entity'
@@ -48,6 +49,9 @@ export class Item extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   links?: {}
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => Category, pivotEntity: () => ItemsCategories })
   categories = new Collection<Category>(this)

--- a/apps/api/src/product/variant.entity.ts
+++ b/apps/api/src/product/variant.entity.ts
@@ -15,7 +15,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import { type TranslatedField } from '@src/common/i18n'
-import { type JSONObject } from '@src/common/z.schema'
+import { type JSONObject, type Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Component } from '@src/process/component.entity'
@@ -63,6 +63,9 @@ export class Variant extends IDCreatedUpdated {
 
   @Property({ index: true })
   code?: string
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => Org, pivotEntity: () => VariantsOrgs })
   orgs = new Collection<Org>(this)

--- a/apps/api/src/users/org.entity.ts
+++ b/apps/api/src/users/org.entity.ts
@@ -13,7 +13,7 @@ import {
 } from '@mikro-orm/core'
 
 import { defaultTranslatedField, type TranslatedField } from '@src/common/i18n'
-import { type JSONObject } from '@src/common/z.schema'
+import { type JSONObject, type Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Process } from '@src/process/process.entity'
 import { Variant } from '@src/product/variant.entity'
@@ -41,6 +41,9 @@ export class Org extends IDCreatedUpdated {
 
   @Property({ fieldName: 'name_translations', type: 'json' })
   nameTr: TranslatedField = defaultTranslatedField()
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @ManyToMany({ entity: () => User, mappedBy: 'orgs' })
   users = new Collection<User>(this)

--- a/apps/api/src/users/org.entity.ts
+++ b/apps/api/src/users/org.entity.ts
@@ -16,6 +16,7 @@ import { defaultTranslatedField, type TranslatedField } from '@src/common/i18n'
 import { type JSONObject, type Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Process } from '@src/process/process.entity'
+import { Program } from '@src/process/program.entity'
 import { Variant } from '@src/product/variant.entity'
 import { User } from '@src/users/users.entity'
 
@@ -56,6 +57,9 @@ export class Org extends IDCreatedUpdated {
 
   @OneToMany({ mappedBy: 'org' })
   processes = new Collection<Process>(this)
+
+  @ManyToMany({ entity: () => Program, mappedBy: 'orgs' })
+  programs = new Collection<Program>(this)
 
   @OneToMany({ mappedBy: 'org' })
   history = new Collection<OrgHistory>(this)

--- a/apps/api/src/users/users.entity.ts
+++ b/apps/api/src/users/users.entity.ts
@@ -11,6 +11,7 @@ import type { Opt } from '@mikro-orm/core'
 
 import { Account } from '@src/auth/account.entity'
 import { Session } from '@src/auth/session.entity'
+import type { Rank } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Org } from '@src/users/org.entity'
 
@@ -62,6 +63,9 @@ export class User extends IDCreatedUpdated {
 
   @Property()
   role?: string
+
+  @Property({ type: 'json' })
+  rank?: Rank
 
   @OneToMany({ mappedBy: 'user' })
   sessions = new Collection<Session>(this)

--- a/apps/api/test/gql/gql.ts
+++ b/apps/api/test/gql/gql.ts
@@ -188,6 +188,10 @@ type Documents = {
     "\n          mutation FlowMergeChange($id: ID!) {\n            mergeChange(id: $id) {\n              change {\n                id\n                status\n              }\n            }\n          }\n        ": typeof types.FlowMergeChangeDocument,
     "\n          query FlowGetProcess($id: ID!) {\n            process(id: $id) {\n              id\n              name\n              material {\n                id\n              }\n              org {\n                id\n              }\n            }\n          }\n        ": typeof types.FlowGetProcessDocument,
     "\n          query FlowGetOrg($id: ID!) {\n            org(id: $id) {\n              id\n              name\n              slug\n            }\n          }\n        ": typeof types.FlowGetOrgDocument,
+    "\n        query ProgramResolverListPrograms($first: Int) {\n          programs(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n          }\n        }\n      ": typeof types.ProgramResolverListProgramsDocument,
+    "\n        query ProgramResolverGetProgram($id: ID!) {\n          program(id: $id) {\n            id\n            name\n          }\n        }\n      ": typeof types.ProgramResolverGetProgramDocument,
+    "\n        mutation ProgramResolverCreateProgram($input: CreateProgramInput!) {\n          createProgram(input: $input) {\n            program {\n              id\n              name\n              status\n            }\n          }\n        }\n      ": typeof types.ProgramResolverCreateProgramDocument,
+    "\n        mutation ProgramResolverUpdateProgram($input: UpdateProgramInput!) {\n          updateProgram(input: $input) {\n            program {\n              id\n              name\n            }\n          }\n        }\n      ": typeof types.ProgramResolverUpdateProgramDocument,
     "\n        query TagResolverListTags($first: Int) {\n          tags(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n            pageInfo {\n              hasNextPage\n              hasPreviousPage\n            }\n          }\n        }\n      ": typeof types.TagResolverListTagsDocument,
     "\n        mutation TagResolverCreateTagDefinition($input: CreateTagDefinitionInput!) {\n          createTagDefinition(input: $input) {\n            tag {\n              id\n              name\n            }\n          }\n        }\n      ": typeof types.TagResolverCreateTagDefinitionDocument,
     "\n        query TagResolverGetTag($id: ID!) {\n          tag(id: $id) {\n            id\n            name\n          }\n        }\n      ": typeof types.TagResolverGetTagDocument,
@@ -487,6 +491,10 @@ const documents: Documents = {
     "\n          mutation FlowMergeChange($id: ID!) {\n            mergeChange(id: $id) {\n              change {\n                id\n                status\n              }\n            }\n          }\n        ": types.FlowMergeChangeDocument,
     "\n          query FlowGetProcess($id: ID!) {\n            process(id: $id) {\n              id\n              name\n              material {\n                id\n              }\n              org {\n                id\n              }\n            }\n          }\n        ": types.FlowGetProcessDocument,
     "\n          query FlowGetOrg($id: ID!) {\n            org(id: $id) {\n              id\n              name\n              slug\n            }\n          }\n        ": types.FlowGetOrgDocument,
+    "\n        query ProgramResolverListPrograms($first: Int) {\n          programs(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n          }\n        }\n      ": types.ProgramResolverListProgramsDocument,
+    "\n        query ProgramResolverGetProgram($id: ID!) {\n          program(id: $id) {\n            id\n            name\n          }\n        }\n      ": types.ProgramResolverGetProgramDocument,
+    "\n        mutation ProgramResolverCreateProgram($input: CreateProgramInput!) {\n          createProgram(input: $input) {\n            program {\n              id\n              name\n              status\n            }\n          }\n        }\n      ": types.ProgramResolverCreateProgramDocument,
+    "\n        mutation ProgramResolverUpdateProgram($input: UpdateProgramInput!) {\n          updateProgram(input: $input) {\n            program {\n              id\n              name\n            }\n          }\n        }\n      ": types.ProgramResolverUpdateProgramDocument,
     "\n        query TagResolverListTags($first: Int) {\n          tags(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n            pageInfo {\n              hasNextPage\n              hasPreviousPage\n            }\n          }\n        }\n      ": types.TagResolverListTagsDocument,
     "\n        mutation TagResolverCreateTagDefinition($input: CreateTagDefinitionInput!) {\n          createTagDefinition(input: $input) {\n            tag {\n              id\n              name\n            }\n          }\n        }\n      ": types.TagResolverCreateTagDefinitionDocument,
     "\n        query TagResolverGetTag($id: ID!) {\n          tag(id: $id) {\n            id\n            name\n          }\n        }\n      ": types.TagResolverGetTagDocument,
@@ -1322,6 +1330,22 @@ export function graphql(source: "\n          query FlowGetProcess($id: ID!) {\n 
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n          query FlowGetOrg($id: ID!) {\n            org(id: $id) {\n              id\n              name\n              slug\n            }\n          }\n        "): (typeof documents)["\n          query FlowGetOrg($id: ID!) {\n            org(id: $id) {\n              id\n              name\n              slug\n            }\n          }\n        "];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n        query ProgramResolverListPrograms($first: Int) {\n          programs(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n          }\n        }\n      "): (typeof documents)["\n        query ProgramResolverListPrograms($first: Int) {\n          programs(first: $first) {\n            nodes {\n              id\n              name\n            }\n            totalCount\n          }\n        }\n      "];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n        query ProgramResolverGetProgram($id: ID!) {\n          program(id: $id) {\n            id\n            name\n          }\n        }\n      "): (typeof documents)["\n        query ProgramResolverGetProgram($id: ID!) {\n          program(id: $id) {\n            id\n            name\n          }\n        }\n      "];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n        mutation ProgramResolverCreateProgram($input: CreateProgramInput!) {\n          createProgram(input: $input) {\n            program {\n              id\n              name\n              status\n            }\n          }\n        }\n      "): (typeof documents)["\n        mutation ProgramResolverCreateProgram($input: CreateProgramInput!) {\n          createProgram(input: $input) {\n            program {\n              id\n              name\n              status\n            }\n          }\n        }\n      "];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n        mutation ProgramResolverUpdateProgram($input: UpdateProgramInput!) {\n          updateProgram(input: $input) {\n            program {\n              id\n              name\n            }\n          }\n        }\n      "): (typeof documents)["\n        mutation ProgramResolverUpdateProgram($input: UpdateProgramInput!) {\n          updateProgram(input: $input) {\n            program {\n              id\n              name\n            }\n          }\n        }\n      "];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/apps/api/test/gql/graphql.ts
+++ b/apps/api/test/gql/graphql.ts
@@ -1028,6 +1028,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1889,6 +1890,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/api/test/gql/graphql.ts
+++ b/apps/api/test/gql/graphql.ts
@@ -640,6 +640,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -774,7 +806,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -785,6 +817,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1138,6 +1171,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1161,6 +1195,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1199,6 +1234,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1315,6 +1355,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1621,6 +1666,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1651,6 +1806,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1789,6 +1947,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2125,6 +2296,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 
@@ -2383,6 +2555,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {
@@ -3952,6 +4165,7 @@ export type FlowCreateProcessMutation = { __typename?: 'Mutation', createProcess
             | { __typename?: 'Org' }
             | { __typename?: 'Place' }
             | { __typename: 'Process', id: string, name?: string | null, material?: { __typename?: 'Material', id: string } | null, org?: { __typename?: 'Org', id: string } | null }
+            | { __typename?: 'Program' }
             | { __typename?: 'Variant' }
            | null }> | null } } | null } | null };
 
@@ -3968,6 +4182,7 @@ export type FlowUpdateProcessMaterialMutation = { __typename?: 'Mutation', updat
             | { __typename?: 'Org' }
             | { __typename?: 'Place' }
             | { __typename: 'Process', id: string, name?: string | null, material?: { __typename?: 'Material', id: string } | null, org?: { __typename?: 'Org', id: string } | null }
+            | { __typename?: 'Program' }
             | { __typename?: 'Variant' }
            | null }> | null } } | null } | null };
 
@@ -4012,6 +4227,34 @@ export type FlowGetOrgQueryVariables = Exact<{
 
 
 export type FlowGetOrgQuery = { __typename?: 'Query', org?: { __typename?: 'Org', id: string, name: string, slug: string } | null };
+
+export type ProgramResolverListProgramsQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type ProgramResolverListProgramsQuery = { __typename?: 'Query', programs: { __typename?: 'ProgramsPage', totalCount: number, nodes?: Array<{ __typename?: 'Program', id: string, name: string }> | null } };
+
+export type ProgramResolverGetProgramQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type ProgramResolverGetProgramQuery = { __typename?: 'Query', program?: { __typename?: 'Program', id: string, name: string } | null };
+
+export type ProgramResolverCreateProgramMutationVariables = Exact<{
+  input: CreateProgramInput;
+}>;
+
+
+export type ProgramResolverCreateProgramMutation = { __typename?: 'Mutation', createProgram?: { __typename?: 'CreateProgramOutput', program?: { __typename?: 'Program', id: string, name: string, status: string } | null } | null };
+
+export type ProgramResolverUpdateProgramMutationVariables = Exact<{
+  input: UpdateProgramInput;
+}>;
+
+
+export type ProgramResolverUpdateProgramMutation = { __typename?: 'Mutation', updateProgram?: { __typename?: 'UpdateProgramOutput', program?: { __typename?: 'Program', id: string, name: string } | null } | null };
 
 export type TagResolverListTagsQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -5147,6 +5390,10 @@ export const FlowApproveChangeDocument = {"kind":"Document","definitions":[{"kin
 export const FlowMergeChangeDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"FlowMergeChange"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"mergeChange"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"change"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<FlowMergeChangeMutation, FlowMergeChangeMutationVariables>;
 export const FlowGetProcessDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FlowGetProcess"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"process"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"material"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}},{"kind":"Field","name":{"kind":"Name","value":"org"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]} as unknown as DocumentNode<FlowGetProcessQuery, FlowGetProcessQueryVariables>;
 export const FlowGetOrgDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FlowGetOrg"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"org"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}}]}}]}}]} as unknown as DocumentNode<FlowGetOrgQuery, FlowGetOrgQueryVariables>;
+export const ProgramResolverListProgramsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ProgramResolverListPrograms"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"first"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"programs"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"first"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}}]}}]}}]} as unknown as DocumentNode<ProgramResolverListProgramsQuery, ProgramResolverListProgramsQueryVariables>;
+export const ProgramResolverGetProgramDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"ProgramResolverGetProgram"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"program"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<ProgramResolverGetProgramQuery, ProgramResolverGetProgramQueryVariables>;
+export const ProgramResolverCreateProgramDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ProgramResolverCreateProgram"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateProgramInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createProgram"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"program"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"status"}}]}}]}}]}}]} as unknown as DocumentNode<ProgramResolverCreateProgramMutation, ProgramResolverCreateProgramMutationVariables>;
+export const ProgramResolverUpdateProgramDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ProgramResolverUpdateProgram"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateProgramInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateProgram"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"program"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<ProgramResolverUpdateProgramMutation, ProgramResolverUpdateProgramMutationVariables>;
 export const TagResolverListTagsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TagResolverListTags"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"first"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tags"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"first"},"value":{"kind":"Variable","name":{"kind":"Name","value":"first"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"nodes"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}},{"kind":"Field","name":{"kind":"Name","value":"totalCount"}},{"kind":"Field","name":{"kind":"Name","value":"pageInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"hasNextPage"}},{"kind":"Field","name":{"kind":"Name","value":"hasPreviousPage"}}]}}]}}]}}]} as unknown as DocumentNode<TagResolverListTagsQuery, TagResolverListTagsQueryVariables>;
 export const TagResolverCreateTagDefinitionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"TagResolverCreateTagDefinition"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateTagDefinitionInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createTagDefinition"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tag"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<TagResolverCreateTagDefinitionMutation, TagResolverCreateTagDefinitionMutationVariables>;
 export const TagResolverGetTagDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"TagResolverGetTag"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"tag"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]} as unknown as DocumentNode<TagResolverGetTagQuery, TagResolverGetTagQueryVariables>;

--- a/apps/api/test/gql/types.generated.ts
+++ b/apps/api/test/gql/types.generated.ts
@@ -636,6 +636,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -770,7 +802,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -781,6 +813,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1134,6 +1167,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1157,6 +1191,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1195,6 +1230,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1311,6 +1351,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1617,6 +1662,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1647,6 +1802,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1785,6 +1943,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2121,6 +2292,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 
@@ -2379,6 +2551,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {

--- a/apps/api/test/gql/types.generated.ts
+++ b/apps/api/test/gql/types.generated.ts
@@ -1024,6 +1024,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1885,6 +1886,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/frontend/app/gql/graphql.ts
+++ b/apps/frontend/app/gql/graphql.ts
@@ -1028,6 +1028,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1889,6 +1890,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/frontend/app/gql/graphql.ts
+++ b/apps/frontend/app/gql/graphql.ts
@@ -2125,6 +2125,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/apps/frontend/app/gql/graphql.ts
+++ b/apps/frontend/app/gql/graphql.ts
@@ -640,6 +640,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -774,7 +806,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -785,6 +817,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1138,6 +1171,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1161,6 +1195,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1199,6 +1234,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1315,6 +1355,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1621,6 +1666,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1651,6 +1806,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1789,6 +1947,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2386,6 +2557,47 @@ export type UpdateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
+};
+
 export type UpdateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -2871,6 +3083,7 @@ export type ChangeQueryQuery = { __typename?: 'Query', change?: { __typename?: '
           | { __typename?: 'Org' }
           | { __typename?: 'Place', name?: string | null }
           | { __typename?: 'Process', name?: string | null }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant', name?: string | null }
          | null, changes?:
           | { __typename?: 'Category', name_req: string }
@@ -2880,6 +3093,7 @@ export type ChangeQueryQuery = { __typename?: 'Query', change?: { __typename?: '
           | { __typename?: 'Org' }
           | { __typename?: 'Place', name?: string | null }
           | { __typename?: 'Process', name?: string | null }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant', name?: string | null }
          | null }> | null } } | null };
 

--- a/apps/frontend/app/gql/types.generated.ts
+++ b/apps/frontend/app/gql/types.generated.ts
@@ -2121,6 +2121,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/apps/frontend/app/gql/types.generated.ts
+++ b/apps/frontend/app/gql/types.generated.ts
@@ -1024,6 +1024,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1885,6 +1886,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/frontend/app/gql/types.generated.ts
+++ b/apps/frontend/app/gql/types.generated.ts
@@ -636,6 +636,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -770,7 +802,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -781,6 +813,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1134,6 +1167,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1157,6 +1191,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1195,6 +1230,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1311,6 +1351,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1617,6 +1662,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1647,6 +1802,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1785,6 +1943,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2380,6 +2551,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {

--- a/apps/science/app/gql/graphql.ts
+++ b/apps/science/app/gql/graphql.ts
@@ -640,6 +640,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -774,7 +806,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -785,6 +817,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1138,6 +1171,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1161,6 +1195,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1199,6 +1234,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1315,6 +1355,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1621,6 +1666,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1651,6 +1806,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1789,6 +1947,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2386,6 +2557,47 @@ export type UpdateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
+};
+
 export type UpdateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -2904,6 +3116,7 @@ export type CategoryChangesQueryQuery = { __typename?: 'Query', change?: { __typ
           | { __typename?: 'Org' }
           | { __typename?: 'Place' }
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -2939,6 +3152,7 @@ export type ChangeDetailQuery = { __typename?: 'Query', change?: { __typename?: 
           | { __typename: 'Org' }
           | { __typename: 'Place' }
           | { __typename: 'Process' }
+          | { __typename: 'Program' }
           | { __typename: 'Variant' }
          | null }> | null } } | null };
 
@@ -3050,6 +3264,7 @@ export type ComponentChangesQueryQuery = { __typename?: 'Query', change?: { __ty
           | { __typename?: 'Org' }
           | { __typename?: 'Place' }
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -3145,6 +3360,7 @@ export type ItemsChangesQueryQuery = { __typename?: 'Query', change?: { __typena
           | { __typename?: 'Org' }
           | { __typename?: 'Place' }
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -3240,6 +3456,7 @@ export type OrgsChangesQueryQuery = { __typename?: 'Query', change?: { __typenam
           )
           | { __typename?: 'Place' }
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -3303,6 +3520,7 @@ export type PlacesChangesQueryQuery = { __typename?: 'Query', change?: { __typen
             & { ' $fragmentRefs'?: { 'ListPlaceFragmentFragment': ListPlaceFragmentFragment } }
           )
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -3392,6 +3610,7 @@ export type ProcessesChangesQueryQuery = { __typename?: 'Query', change?: { __ty
             { __typename?: 'Process' }
             & { ' $fragmentRefs'?: { 'ListProcessFragmentFragment': ListProcessFragmentFragment } }
           )
+          | { __typename?: 'Program' }
           | { __typename?: 'Variant' }
          | null }> | null, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null } } } | null };
 
@@ -3511,6 +3730,7 @@ export type VariantsChangesQueryQuery = { __typename?: 'Query', change?: { __typ
           | { __typename?: 'Org' }
           | { __typename?: 'Place' }
           | { __typename?: 'Process' }
+          | { __typename?: 'Program' }
           | (
             { __typename?: 'Variant' }
             & { ' $fragmentRefs'?: { 'ListVariantFragmentFragment': ListVariantFragmentFragment } }

--- a/apps/science/app/gql/graphql.ts
+++ b/apps/science/app/gql/graphql.ts
@@ -1028,6 +1028,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1889,6 +1890,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/science/app/gql/graphql.ts
+++ b/apps/science/app/gql/graphql.ts
@@ -2125,6 +2125,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/apps/science/app/gql/types.generated.ts
+++ b/apps/science/app/gql/types.generated.ts
@@ -2121,6 +2121,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/apps/science/app/gql/types.generated.ts
+++ b/apps/science/app/gql/types.generated.ts
@@ -1024,6 +1024,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1885,6 +1886,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/apps/science/app/gql/types.generated.ts
+++ b/apps/science/app/gql/types.generated.ts
@@ -636,6 +636,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -770,7 +802,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -781,6 +813,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1134,6 +1167,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1157,6 +1191,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1195,6 +1230,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1311,6 +1351,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1617,6 +1662,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1647,6 +1802,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1785,6 +1943,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2380,6 +2551,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {

--- a/packages/ui/app/gql/graphql.ts
+++ b/packages/ui/app/gql/graphql.ts
@@ -640,6 +640,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -774,7 +806,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -785,6 +817,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1138,6 +1171,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1161,6 +1195,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1199,6 +1234,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1315,6 +1355,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1621,6 +1666,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1651,6 +1806,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1789,6 +1947,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2384,6 +2555,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {

--- a/packages/ui/app/gql/graphql.ts
+++ b/packages/ui/app/gql/graphql.ts
@@ -1028,6 +1028,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1889,6 +1890,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/packages/ui/app/gql/graphql.ts
+++ b/packages/ui/app/gql/graphql.ts
@@ -2125,6 +2125,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/packages/ui/app/gql/types.generated.ts
+++ b/packages/ui/app/gql/types.generated.ts
@@ -2121,6 +2121,7 @@ export enum TagType {
   Org = 'ORG',
   Place = 'PLACE',
   Process = 'PROCESS',
+  Program = 'PROGRAM',
   Variant = 'VARIANT'
 }
 

--- a/packages/ui/app/gql/types.generated.ts
+++ b/packages/ui/app/gql/types.generated.ts
@@ -1024,6 +1024,7 @@ export type Material = Named & {
   processes: ProcessPage;
   /** The physical form or shape of the material (e.g. film, rigid, fibre) */
   shape?: Maybe<Scalars['String']['output']>;
+  synonyms?: Maybe<Array<Scalars['String']['output']>>;
   /** If true, this is an internal technical classification not shown to end-users */
   technical: Scalars['Boolean']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -1885,6 +1886,7 @@ export type Region = {
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   /** Minimum map zoom level at which this region should be displayed */
   minZoom?: Maybe<Scalars['Float']['output']>;

--- a/packages/ui/app/gql/types.generated.ts
+++ b/packages/ui/app/gql/types.generated.ts
@@ -636,6 +636,38 @@ export type CreateProcessOutput = {
   process?: Maybe<Process>;
 };
 
+export type CreateProgramInput = {
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status: Scalars['String']['input'];
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type CreateProgramOutput = {
+  __typename?: 'CreateProgramOutput';
+  change?: Maybe<Change>;
+  program?: Maybe<Program>;
+};
+
 export type CreateSourceInput = {
   content?: InputMaybe<Scalars['JSONObject']['input']>;
   contentURL?: InputMaybe<Scalars['String']['input']>;
@@ -770,7 +802,7 @@ export type EditEdge = {
   node: Edit;
 };
 
-export type EditModel = Category | Component | Item | Material | Org | Place | Process | Variant;
+export type EditModel = Category | Component | Item | Material | Org | Place | Process | Program | Variant;
 
 /** Type of the model being edited */
 export enum EditModelType {
@@ -781,6 +813,7 @@ export enum EditModelType {
   Org = 'Org',
   Place = 'Place',
   Process = 'Process',
+  Program = 'Program',
   Variant = 'Variant'
 }
 
@@ -1134,6 +1167,7 @@ export type Mutation = {
   createOrg?: Maybe<CreateOrgOutput>;
   createPlace?: Maybe<CreatePlaceOutput>;
   createProcess?: Maybe<CreateProcessOutput>;
+  createProgram?: Maybe<CreateProgramOutput>;
   createSource?: Maybe<CreateSourceOutput>;
   createTagDefinition?: Maybe<CreateTagDefinitionOutput>;
   createVariant?: Maybe<CreateVariantOutput>;
@@ -1157,6 +1191,7 @@ export type Mutation = {
   updateOrg?: Maybe<UpdateOrgOutput>;
   updatePlace?: Maybe<UpdatePlaceOutput>;
   updateProcess?: Maybe<UpdateProcessOutput>;
+  updateProgram?: Maybe<UpdateProgramOutput>;
   updateSource?: Maybe<UpdateSourceOutput>;
   updateTagDefinition?: Maybe<UpdateTagDefinitionOutput>;
   updateVariant?: Maybe<UpdateVariantOutput>;
@@ -1195,6 +1230,11 @@ export type MutationCreatePlaceArgs = {
 
 export type MutationCreateProcessArgs = {
   input: CreateProcessInput;
+};
+
+
+export type MutationCreateProgramArgs = {
+  input: CreateProgramInput;
 };
 
 
@@ -1311,6 +1351,11 @@ export type MutationUpdatePlaceArgs = {
 
 export type MutationUpdateProcessArgs = {
   input: UpdateProcessInput;
+};
+
+
+export type MutationUpdateProgramArgs = {
+  input: UpdateProgramInput;
 };
 
 
@@ -1617,6 +1662,116 @@ export type ProcessVariantInput = {
   id: Scalars['ID']['input'];
 };
 
+/** An administrative description of circular economy processes */
+export type Program = Named & {
+  __typename?: 'Program';
+  createdAt: Scalars['DateTime']['output'];
+  desc?: Maybe<Scalars['String']['output']>;
+  /** Audit history of changes to this program */
+  history: ProgramHistoryPage;
+  /** The ID of the model */
+  id: Scalars['ID']['output'];
+  instructions?: Maybe<Scalars['JSONObject']['output']>;
+  name: Scalars['String']['output'];
+  /** Organizations involved in this program */
+  orgs: OrgsPage;
+  /** Processes run by this program */
+  processes: ProcessPage;
+  region?: Maybe<Region>;
+  social?: Maybe<Scalars['JSONObject']['output']>;
+  status: Scalars['String']['output'];
+  /** Metadata tags applied to this program */
+  tags: TagPage;
+  updatedAt: Scalars['DateTime']['output'];
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An administrative description of circular economy processes */
+export type ProgramTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+export type ProgramEdge = {
+  __typename?: 'ProgramEdge';
+  cursor: Scalars['String']['output'];
+  node: Program;
+};
+
+export type ProgramHistory = {
+  __typename?: 'ProgramHistory';
+  changes?: Maybe<Program>;
+  datetime: Scalars['DateTime']['output'];
+  original?: Maybe<Program>;
+  program: Program;
+  user: User;
+};
+
+export type ProgramHistoryEdge = {
+  __typename?: 'ProgramHistoryEdge';
+  cursor: Scalars['String']['output'];
+  node: ProgramHistory;
+};
+
+export type ProgramHistoryPage = {
+  __typename?: 'ProgramHistoryPage';
+  edges?: Maybe<Array<ProgramHistoryEdge>>;
+  nodes?: Maybe<Array<ProgramHistory>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
+export type ProgramOrgsInput = {
+  id: Scalars['ID']['input'];
+  role?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type ProgramProcessesInput = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProgramTagsInput = {
+  id: Scalars['ID']['input'];
+  meta?: InputMaybe<Scalars['JSONObject']['input']>;
+};
+
+export type ProgramsPage = {
+  __typename?: 'ProgramsPage';
+  edges?: Maybe<Array<ProgramEdge>>;
+  nodes?: Maybe<Array<Program>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars['Int']['output'];
+};
+
 export type Query = {
   __typename?: 'Query';
   categories: CategoriesPage;
@@ -1647,6 +1802,9 @@ export type Query = {
   process?: Maybe<Process>;
   processSchema?: Maybe<ModelEditSchema>;
   processes: ProcessPage;
+  program?: Maybe<Program>;
+  programSchema?: Maybe<ModelEditSchema>;
+  programs: ProgramsPage;
   region?: Maybe<Region>;
   regions: RegionsPage;
   search: SearchResultPage;
@@ -1785,6 +1943,19 @@ export type QueryProcessesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
   material?: InputMaybe<Scalars['String']['input']>;
   region?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryProgramArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type QueryProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2380,6 +2551,47 @@ export type UpdateProcessOutput = {
   currentProcess?: Maybe<Process>;
   /** The process including the proposed changes */
   process?: Maybe<Process>;
+};
+
+export type UpdateProgramInput = {
+  addOrgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  addProcesses?: InputMaybe<Array<ProgramProcessesInput>>;
+  /** Sources to associate with this change */
+  addSources?: InputMaybe<Array<SourceInput>>;
+  addTags?: InputMaybe<Array<ProgramTagsInput>>;
+  /** If true, immediately apply (merge) the change after creation */
+  apply?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Details for a new change to create for this edit */
+  change?: InputMaybe<CreateChangeInput>;
+  /** ID of an existing change to add this edit to */
+  changeID?: InputMaybe<Scalars['ID']['input']>;
+  desc?: InputMaybe<Scalars['String']['input']>;
+  descTr?: InputMaybe<Array<TranslatedInput>>;
+  id: Scalars['ID']['input'];
+  instructions?: InputMaybe<Scalars['JSONObject']['input']>;
+  /** Language code for text input fields (BCP 47, e.g. "en") */
+  lang?: InputMaybe<Scalars['String']['input']>;
+  name?: InputMaybe<Scalars['String']['input']>;
+  nameTr?: InputMaybe<Array<TranslatedInput>>;
+  orgs?: InputMaybe<Array<ProgramOrgsInput>>;
+  processes?: InputMaybe<Array<ProgramProcessesInput>>;
+  region?: InputMaybe<Scalars['ID']['input']>;
+  removeOrgs?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeProcesses?: InputMaybe<Array<Scalars['ID']['input']>>;
+  /** IDs of sources to remove from this change */
+  removeSources?: InputMaybe<Array<Scalars['ID']['input']>>;
+  removeTags?: InputMaybe<Array<Scalars['ID']['input']>>;
+  social?: InputMaybe<Scalars['JSONObject']['input']>;
+  status?: InputMaybe<Scalars['String']['input']>;
+  tags?: InputMaybe<Array<ProgramTagsInput>>;
+};
+
+export type UpdateProgramOutput = {
+  __typename?: 'UpdateProgramOutput';
+  change?: Maybe<Change>;
+  /** The program as currently persisted in the database */
+  currentProgram?: Maybe<Program>;
+  program?: Maybe<Program>;
 };
 
 export type UpdateSourceInput = {


### PR DESCRIPTION
- **feat(api): Add rank columns, Region desc, Material synonyms**
- **feat(api): Programs! DB changes first**
- **feat(api): GraphQL interface for programs**

Closes #89, Closes #83 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Programs to the API with full GraphQL support (queries, mutations, history) and relationships to regions, orgs, processes, and tags. Also adds rank metadata across entities, region descriptions, and locale-aware material synonyms.

- **New Features**
  - Programs: DB schema, relations (orgs/processes/tags), GraphQL models/resolver/service, create/update with change tracking, tests and seed data.
  - Rank and metadata: added `rank` JSON to Category, Item, Component, Process, Tag, Org, Place, Variant, User; Region now has `desc`; Materials support localized `synonyms` (flattened in GraphQL).
  - i18n: added `pick` helper to select localized structured data.

- **Migration**
  - Run database migrations.
  - Regenerate GraphQL types in apps and packages.

<sup>Written for commit c9c010f00e94933812fad631adc07021396acc6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

