### PR TITLE
fix(api): Use hybrid search only when embeddings are present

### DIFF
--- a/apps/api/src/search/search.backend.ts
+++ b/apps/api/src/search/search.backend.ts
@@ -82,6 +82,7 @@ export interface SearchBackend {
   listCollections(): Promise<string[]>
   search(request: SearchBackendSearchRequest): Promise<SearchBackendSearchResult>
   multiSearch(request: SearchBackendMultiSearchRequest): Promise<SearchBackendMultiSearchResult>
+  supportsVectorSearch(collection: string): Promise<boolean>
 }
 
 export const SEARCH_BACKEND = Symbol('SEARCH_BACKEND')

--- a/apps/api/src/search/search.resolver.spec.ts
+++ b/apps/api/src/search/search.resolver.spec.ts
@@ -43,6 +43,7 @@ describe('SearchResolver (integration)', () => {
         search: searchMock,
         multiSearch: multiSearchMock,
         listCollections: vi.fn().mockResolvedValue([]),
+        supportsVectorSearch: vi.fn().mockResolvedValue(true),
       })
       .overrideProvider(MistralService)
       .useValue({

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -181,7 +181,11 @@ export class SearchService {
 
     const words = textQuery.trim().split(/\s+/)
     let vector: number[] | undefined
-    if (words.length >= 2 && words[0] !== '') {
+    if (
+      words.length >= 2 &&
+      words[0] !== '' &&
+      (await this.searchBackend.supportsVectorSearch(index))
+    ) {
       vector = (await this.mistralService.getEmbedding(textQuery)) ?? undefined
     }
 
@@ -241,21 +245,29 @@ export class SearchService {
 
     const words = textQuery.trim().split(/\s+/)
     let vector: number[] | undefined
-    if (words.length >= 2 && words[0] !== '') {
+    const indexesWithSupport = await Promise.all(
+      searchableIndexes.map(async (idx) => ({
+        idx,
+        supports: await this.searchBackend.supportsVectorSearch(idx),
+      })),
+    )
+    const hasAnySupport = indexesWithSupport.some((i) => i.supports)
+
+    if (words.length >= 2 && words[0] !== '' && hasAnySupport) {
       vector = (await this.mistralService.getEmbedding(textQuery)) ?? undefined
     }
 
     const lang = this.i18n.getLang()
     const fetchLimit = (limit ? limit + 1 : 11) + (offset ?? 0)
     const multiResult = await this.searchBackend.multiSearch({
-      searches: searchableIndexes.map((idx) => ({
+      searches: indexesWithSupport.map(({ idx, supports }) => ({
         collection: idx,
         query: textQuery,
         options: {
           lang,
           ...(filtersByIndex.get(idx)?.length ? { filters: filtersByIndex.get(idx) } : {}),
           geo,
-          vector,
+          vector: supports ? vector : undefined,
           limit: fetchLimit,
         },
       })),

--- a/apps/api/src/search/typesense.service.spec.ts
+++ b/apps/api/src/search/typesense.service.spec.ts
@@ -262,4 +262,49 @@ describe('TypesenseSearchService', () => {
       ],
     })
   })
+
+  test('supports vector search only when "embedding" field is present', async () => {
+    const { service, mockCollectionsRetrieve } = makeTypesenseSearchService()
+    mockCollectionsRetrieve.mockResolvedValue([
+      { name: 'with-embedding', fields: [{ name: 'embedding', type: 'float[]' }] },
+      { name: 'with-image-embedding', fields: [{ name: 'image_embedding', type: 'float[]' }] },
+      { name: 'without-embedding', fields: [{ name: 'name', type: 'string' }] },
+    ])
+
+    expect(await service.supportsVectorSearch('with-embedding')).toBe(true)
+    expect(await service.supportsVectorSearch('with-image-embedding')).toBe(false)
+    expect(await service.supportsVectorSearch('without-embedding')).toBe(false)
+  })
+
+  test('includes vector_query in search params when vector is provided and supported', async () => {
+    const { service, mockCollectionsRetrieve, mockMultiSearch } = makeTypesenseSearchService()
+    mockCollectionsRetrieve.mockResolvedValue([
+      {
+        name: 'supported',
+        fields: [
+          { name: 'embedding', type: 'float[]' },
+          { name: 'name', type: 'string' },
+        ],
+      },
+    ])
+
+    await service.search({
+      collection: 'supported',
+      query: 'test',
+      options: {
+        vector: [0.1, 0.2, 0.3],
+      },
+    })
+
+    expect(mockMultiSearch).toHaveBeenCalledWith(
+      {
+        searches: [
+          expect.objectContaining({
+            vector_query: 'embedding:([0.1,0.2,0.3])',
+          }),
+        ],
+      },
+      {},
+    )
+  })
 })

--- a/apps/api/src/search/typesense.service.ts
+++ b/apps/api/src/search/typesense.service.ts
@@ -101,6 +101,11 @@ export class TypesenseSearchService implements SearchBackend, OnModuleInit {
     return (await this.getCollectionSchemas()).map((collection) => collection.name)
   }
 
+  async supportsVectorSearch(collection: string): Promise<boolean> {
+    const schema = await this.getCollectionSchema(collection)
+    return schema.fields.some((f) => f.name === 'embedding')
+  }
+
   async search(request: SearchBackendSearchRequest): Promise<SearchBackendSearchResult> {
     const multiResult = await this.multiSearch({
       searches: [request],
@@ -253,9 +258,11 @@ export class TypesenseSearchService implements SearchBackend, OnModuleInit {
     includeCollection = false,
   ) {
     const filterBy = this.buildFilterBy(request.options?.filters, request.options?.geo)
-    const vectorQuery = request.options?.vector
-      ? `embedding:([${request.options.vector.join(',')}])`
-      : undefined
+    const hasVectorField = schema.fields.some((f) => f.name === 'embedding')
+    const vectorQuery =
+      request.options?.vector && hasVectorField
+        ? `embedding:([${request.options.vector.join(',')}])`
+        : undefined
 
     return {
       ...(includeCollection ? { collection: request.collection } : {}),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use hybrid (keyword + vector) search only when a collection has embeddings. This prevents bad queries and weighting on indexes without embeddings.

- **Bug Fixes**
  - Added `supportsVectorSearch` to the search backend and implemented it in `Typesense` by checking for an `embedding` field.
  - `SearchService` now requests embeddings only if the target index supports vectors; in multi-search, vectors are sent per index only when supported.
  - `Typesense` now builds `vector_query` only when an embedding field exists, avoiding invalid queries.
  - Updated tests to cover support detection and `vector_query` inclusion.

<sup>Written for commit a37b0fedb2fac3d23730211c09a6e99ca028e708. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

