### PR TITLE
api: Track entity view events

### DIFF
--- a/apps/api/src/common/common.module.ts
+++ b/apps/api/src/common/common.module.ts
@@ -8,6 +8,7 @@ import { AcceptLanguageResolver, HeaderResolver, I18nModule, QueryResolver } fro
 
 import { BaseSchemaService } from '@src/common/base.schema'
 import { isProd } from '@src/common/common.utils'
+import { EntityViewInterceptor } from '@src/common/entity-view.interceptor'
 import { I18nService } from '@src/common/i18n.service'
 import { MetaService } from '@src/common/meta.service'
 import { PosthogService } from '@src/common/posthog.service'
@@ -45,6 +46,7 @@ import { ZService } from '@src/common/z.service'
     PosthogService,
     RedisService,
     StorageService,
+    EntityViewInterceptor,
   ],
   exports: [
     TransformService,
@@ -55,6 +57,7 @@ import { ZService } from '@src/common/z.service'
     PosthogService,
     RedisService,
     StorageService,
+    EntityViewInterceptor,
   ],
 })
 export class CommonModule {}

--- a/apps/api/src/common/entity-view.decorator.ts
+++ b/apps/api/src/common/entity-view.decorator.ts
@@ -1,0 +1,10 @@
+import { applyDecorators, SetMetadata, UseInterceptors } from '@nestjs/common'
+
+import { ENTITY_VIEW_TYPE_KEY, EntityViewInterceptor } from '@src/common/entity-view.interceptor'
+
+export function TrackEntityView(entityType: string) {
+  return applyDecorators(
+    SetMetadata(ENTITY_VIEW_TYPE_KEY, entityType),
+    UseInterceptors(EntityViewInterceptor),
+  )
+}

--- a/apps/api/src/common/entity-view.interceptor.ts
+++ b/apps/api/src/common/entity-view.interceptor.ts
@@ -1,0 +1,29 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { Observable } from 'rxjs'
+import { tap } from 'rxjs/operators'
+
+import { PosthogService } from '@src/common/posthog.service'
+
+export const ENTITY_VIEW_TYPE_KEY = 'ENTITY_VIEW_TYPE'
+
+@Injectable()
+export class EntityViewInterceptor implements NestInterceptor {
+  constructor(
+    private readonly posthog: PosthogService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const entityType = this.reflector.get<string>(ENTITY_VIEW_TYPE_KEY, context.getHandler())
+    if (!entityType) return next.handle()
+
+    return next.handle().pipe(
+      tap((result) => {
+        const id: string | undefined = (result as any)?.id
+        if (!result || !id) return
+        this.posthog.captureEntityView(entityType, id)
+      }),
+    )
+  }
+}

--- a/apps/api/src/common/posthog.service.ts
+++ b/apps/api/src/common/posthog.service.ts
@@ -29,6 +29,24 @@ export class PosthogService implements OnModuleDestroy {
     }
   }
 
+  capture(event: string, properties: Record<string, unknown>) {
+    if (!this.client) return
+    const session = this.cls.get<UserSession | null>('session')
+    const distinctId = session?.user?.id ?? 'anonymous'
+    this.client.capture({ distinctId, event, properties })
+  }
+
+  captureEntityView(entityType: string, entityId: string) {
+    const rawLocation = this.cls.get<string | undefined>('x-location')
+    const isRegionId = rawLocation?.startsWith('wof_')
+    this.capture('view_entity', {
+      entity_type: entityType,
+      entity_id: entityId,
+      region_id: isRegionId ? rawLocation : undefined,
+      coordinates: !isRegionId ? rawLocation : undefined,
+    })
+  }
+
   captureException(exception: unknown) {
     if (!this.client) return
 

--- a/apps/api/src/geo/place.resolver.ts
+++ b/apps/api/src/geo/place.resolver.ts
@@ -3,6 +3,7 @@ import { Args, ID, Mutation, Parent, Query, ResolveField, Resolver } from '@nest
 import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
 import { OptionalAuth } from '@src/auth/decorators'
 import { Change } from '@src/changes/change.model'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Place as PlaceEntity } from '@src/geo/place.entity'
@@ -67,6 +68,7 @@ export class PlaceResolver {
 
   @Query(() => Place, { name: 'place', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('place')
   async place(@Args('id', { type: () => ID }) id: string): Promise<Place> {
     const place = await this.placeService.findOneByID(id)
     if (!place) {

--- a/apps/api/src/geo/region.resolver.ts
+++ b/apps/api/src/geo/region.resolver.ts
@@ -1,6 +1,7 @@
 import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
 import { OptionalAuth } from '@src/auth/decorators'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { LocationService } from '@src/geo/location.service'
@@ -33,6 +34,7 @@ export class RegionResolver {
 
   @Query(() => Region, { name: 'region', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('region')
   async region(@Args('id', { type: () => ID }) id: string) {
     const region = await this.regionService.findOneByID(id)
     if (!region) {

--- a/apps/api/src/process/component.resolver.ts
+++ b/apps/api/src/process/component.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Region } from '@src/geo/region.model'
@@ -71,6 +72,7 @@ export class ComponentResolver {
 
   @Query(() => Component, { name: 'component', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('component')
   async component(@Args('id', { type: () => ID }) id: string): Promise<Component> {
     const component = await this.componentService.findOneByID(id)
     if (!component) {

--- a/apps/api/src/process/material.resolver.ts
+++ b/apps/api/src/process/material.resolver.ts
@@ -1,6 +1,7 @@
 import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql'
 
 import { OptionalAuth } from '@src/auth/decorators'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Component, ComponentsConnection } from '@src/process/component.model'
@@ -36,6 +37,7 @@ export class MaterialResolver {
 
   @Query(() => Material, { name: 'material', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('material')
   async material(@Args('id', { type: () => ID }) id: string): Promise<Material> {
     const material = await this.materialService.findOneByID(id)
     if (!material) {

--- a/apps/api/src/process/process.resolver.ts
+++ b/apps/api/src/process/process.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Place } from '@src/geo/place.model'
@@ -65,6 +66,7 @@ export class ProcessResolver {
 
   @Query(() => Process, { name: 'process', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('process')
   async process(@Args('id', { type: () => ID }) id: string): Promise<Process> {
     const process = await this.processService.findOneByID(id)
     if (!process) {

--- a/apps/api/src/process/program.resolver.ts
+++ b/apps/api/src/process/program.resolver.ts
@@ -4,6 +4,7 @@ import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
 import { OptionalAuth } from '@src/auth/decorators'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { ModelEditSchema } from '@src/graphql/base.model'
@@ -47,6 +48,7 @@ export class ProgramResolver {
 
   @Query(() => Program, { name: 'program', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('program')
   async program(@Args('id', { type: () => ID }) id: string): Promise<Program> {
     const program = await this.programService.findOneByID(id)
     if (!program) {

--- a/apps/api/src/product/category.resolver.ts
+++ b/apps/api/src/product/category.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
@@ -50,6 +51,7 @@ export class CategoryResolver {
 
   @Query(() => Category, { name: 'category', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('category')
   async category(@Args('id', { type: () => ID }) id: string): Promise<Category> {
     const category = await this.categoryService.findOneByID(id)
     if (!category) {

--- a/apps/api/src/product/item.resolver.ts
+++ b/apps/api/src/product/item.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
@@ -67,6 +68,7 @@ export class ItemResolver {
 
   @Query(() => Item, { name: 'item', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('item')
   async item(@Args('id', { type: () => ID }) id: string): Promise<Item> {
     const item = await this.itemService.findOneByID(id)
     if (!item) {

--- a/apps/api/src/product/variant.resolver.ts
+++ b/apps/api/src/product/variant.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Region, RegionsConnection } from '@src/geo/region.model'
@@ -74,6 +75,7 @@ export class VariantResolver {
 
   @Query(() => Variant, { name: 'variant', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('variant')
   async variant(@Args('id', { type: () => ID }) id: string): Promise<Variant> {
     const variant = await this.variantService.findOneByID(id)
     if (!variant) {

--- a/apps/api/src/users/org.resolver.ts
+++ b/apps/api/src/users/org.resolver.ts
@@ -6,6 +6,7 @@ import { OptionalAuth } from '@src/auth/decorators'
 import { DeleteInput } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { EditService } from '@src/changes/edit.service'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
@@ -65,6 +66,7 @@ export class OrgResolver {
 
   @Query(() => Org, { name: 'org', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('org')
   async org(@Args('id', { type: () => ID }) id: string) {
     const org = await this.orgService.findOneByID(id)
     if (!org) {

--- a/apps/api/src/users/users.resolver.ts
+++ b/apps/api/src/users/users.resolver.ts
@@ -3,6 +3,7 @@ import { Args, ID, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql
 import { AuthUser, type ReqUser } from '@src/auth/auth.guard'
 import { OptionalAuth } from '@src/auth/decorators'
 import { Change, ChangesConnection } from '@src/changes/change.model'
+import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
 import { Org, OrgsConnection } from '@src/users/org.model'
@@ -18,6 +19,7 @@ export class UsersResolver {
 
   @Query(() => User, { name: 'user', nullable: true })
   @OptionalAuth()
+  @TrackEntityView('user')
   async user(@Args('id', { type: () => ID }) id: string) {
     const user = await this.usersService.findOneByID(id)
     if (!user) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Track entity views on single-entity GraphQL queries. Send `view_entity` events to PostHog with user and location context.

- **New Features**
  - Added `@TrackEntityView(entityType)` decorator and `EntityViewInterceptor` to emit `view_entity` with `entity_type` and `entity_id`.
  - Enhanced PostHog service with `capture` and `captureEntityView`; uses session user id or `anonymous`.
  - Includes location context from CLS `x-location`: sets `region_id` for `wof_` values, else `coordinates`.
  - Enabled on queries: place, region, component, material, process, program, category, item, variant, org, user.
  - Registered interceptor in `CommonModule`.

<sup>Written for commit 51ed3ea6c07bc808ceaf2b03fe4940de422205dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

