### PR TITLE
api: Implement GraphQL API rate limiting based on complexity

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -65,6 +65,7 @@
     "dset": "^3.1.4",
     "express": "^5.2.1",
     "graphql": "^16.10.0",
+    "graphql-query-complexity": "^1.1.1",
     "graphql-scalars": "^1.24.1",
     "graphql-upload": "^17.0.0",
     "helmet": "^8.1.0",

--- a/apps/api/src/common/redis.service.ts
+++ b/apps/api/src/common/redis.service.ts
@@ -43,4 +43,27 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
       // ignore
     }
   }
+
+  async throttle(
+    key: string,
+    maxBurst: number,
+    count: number,
+    period: number,
+    quantity: number,
+  ): Promise<[number, number, number, number, number] | null> {
+    try {
+      if (!this.client.isReady) return null
+      const result = await this.client.sendCommand([
+        'CL.THROTTLE',
+        key,
+        String(maxBurst),
+        String(count),
+        String(period),
+        String(quantity),
+      ])
+      return result as unknown as [number, number, number, number, number]
+    } catch {
+      return null
+    }
+  }
 }

--- a/apps/api/src/config/config.ts
+++ b/apps/api/src/config/config.ts
@@ -23,6 +23,17 @@ export default (): Record<string, unknown> => ({
   dragonfly: {
     url: process.env.DRAGONFLY_URL,
   },
+  rateLimit: {
+    enabled: process.env.RATE_LIMIT_ENABLED !== 'false',
+    anonymous: {
+      capacity: parseInt(process.env.RATE_LIMIT_ANON_CAPACITY ?? '300', 10),
+      leakRatePerSec: parseInt(process.env.RATE_LIMIT_ANON_LEAK_RATE ?? '5', 10),
+    },
+    authenticated: {
+      capacity: parseInt(process.env.RATE_LIMIT_AUTH_CAPACITY ?? '3000', 10),
+      leakRatePerSec: parseInt(process.env.RATE_LIMIT_AUTH_LEAK_RATE ?? '50', 10),
+    },
+  },
   typesense: {
     host: process.env.TYPESENSE_HOST,
     apiKey: process.env.TYPESENSE_API_KEY,

--- a/apps/api/src/graphql/graphql.context.ts
+++ b/apps/api/src/graphql/graphql.context.ts
@@ -6,4 +6,5 @@ export interface Context {
 
 export class IncomingMessageWithAuthCode extends IncomingMessage {
   authCode?: number
+  ip?: string
 }

--- a/apps/api/src/graphql/graphql.module.ts
+++ b/apps/api/src/graphql/graphql.module.ts
@@ -20,6 +20,8 @@ import { LuxonDateTimeResolver } from '@src/common/datetime.model'
 import { CacheControlScopeEnum } from '@src/graphql/cache-control'
 import { createGraphQLCache } from '@src/graphql/graphql-cache'
 import { Context, IncomingMessageWithAuthCode } from '@src/graphql/graphql.context'
+import { RateLimitModule } from '@src/rate-limit/rate-limit.module'
+import { RateLimitPlugin } from '@src/rate-limit/rate-limit.plugin'
 
 @Module({})
 export class GraphQLModule {
@@ -112,8 +114,8 @@ export class GraphQLModule {
 
     return {
       module: GraphQLModule,
-      imports: [graphQL],
-      providers: [],
+      imports: [graphQL, AuthModule, RateLimitModule],
+      providers: [RateLimitPlugin],
       exports: [graphQL],
     }
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -22,6 +22,7 @@ async function bootstrap() {
       credentials: true,
     },
   })
+  app.set('trust proxy', 1)
   app.use(
     helmet({
       contentSecurityPolicy: {

--- a/apps/api/src/rate-limit/rate-limit.module.ts
+++ b/apps/api/src/rate-limit/rate-limit.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common'
+
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+@Module({
+  providers: [RateLimitService],
+  exports: [RateLimitService],
+})
+export class RateLimitModule {}

--- a/apps/api/src/rate-limit/rate-limit.plugin.spec.ts
+++ b/apps/api/src/rate-limit/rate-limit.plugin.spec.ts
@@ -1,0 +1,86 @@
+import { ConfigService } from '@nestjs/config'
+import { GraphQLSchemaHost } from '@nestjs/graphql'
+import { buildSchema, parse } from 'graphql'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { AuthService } from '@src/auth/auth.service'
+import { RateLimitPlugin } from '@src/rate-limit/rate-limit.plugin'
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+describe('RateLimitPlugin', () => {
+  let plugin: RateLimitPlugin
+  let rateLimitService: { consume: ReturnType<typeof vi.fn> }
+  let authService: { api: { getSession: ReturnType<typeof vi.fn> } }
+  let configService: { get: ReturnType<typeof vi.fn> }
+
+  const schema = buildSchema('type Query { __typename: String }')
+  const document = parse('{ __typename }')
+
+  beforeEach(() => {
+    rateLimitService = { consume: vi.fn() }
+    authService = { api: { getSession: vi.fn() } }
+    configService = { get: vi.fn().mockReturnValue(undefined) }
+
+    plugin = new RateLimitPlugin(
+      { schema } as GraphQLSchemaHost,
+      rateLimitService as unknown as RateLimitService,
+      authService as unknown as AuthService,
+      configService as unknown as ConfigService,
+    )
+  })
+
+  async function resolveOperation(req?: { headers: Record<string, string>; ip?: string }) {
+    const listener = await plugin.requestDidStart()
+    return listener.didResolveOperation?.({
+      request: { operationName: undefined, variables: undefined },
+      document,
+      contextValue: { req },
+    } as never)
+  }
+
+  test('does nothing when the request is allowed', async () => {
+    rateLimitService.consume.mockResolvedValue({ allowed: true, retryAfterMs: 0 })
+
+    await expect(resolveOperation({ headers: {}, ip: '1.2.3.4' })).resolves.toBeUndefined()
+  })
+
+  test('throws a 429 with a Retry-After header when the request is rate limited', async () => {
+    rateLimitService.consume.mockResolvedValue({ allowed: false, retryAfterMs: 4200 })
+
+    await expect(resolveOperation({ headers: {}, ip: '1.2.3.4' })).rejects.toMatchObject({
+      message: 'Rate limit exceeded',
+      extensions: expect.objectContaining({
+        code: 'RATE_LIMITED',
+        retryAfterMs: 4200,
+        http: expect.objectContaining({
+          status: 429,
+          headers: expect.objectContaining({ get: expect.any(Function) }),
+        }),
+      }),
+    })
+
+    const error = await resolveOperation({ headers: {}, ip: '1.2.3.4' }).catch((err) => err)
+    expect(error.extensions.http.headers.get('retry-after')).toBe('5')
+  })
+
+  test('skips rate limiting entirely when disabled via config', async () => {
+    configService.get.mockImplementation((key: string) =>
+      key === 'rateLimit.enabled' ? false : undefined,
+    )
+
+    await resolveOperation({ headers: {}, ip: '1.2.3.4' })
+
+    expect(rateLimitService.consume).not.toHaveBeenCalled()
+  })
+
+  test('keys anonymous requests by IP and authenticated requests by session user', async () => {
+    rateLimitService.consume.mockResolvedValue({ allowed: true, retryAfterMs: 0 })
+
+    await resolveOperation({ headers: {}, ip: '5.6.7.8' })
+    expect(rateLimitService.consume).toHaveBeenCalledWith('ip:5.6.7.8', 1, 'anonymous')
+
+    authService.api.getSession.mockResolvedValue({ user: { id: 'user-1' } })
+    await resolveOperation({ headers: { cookie: 'session=abc' }, ip: '5.6.7.8' })
+    expect(rateLimitService.consume).toHaveBeenCalledWith('user:user-1', 1, 'authenticated')
+  })
+})

--- a/apps/api/src/rate-limit/rate-limit.plugin.ts
+++ b/apps/api/src/rate-limit/rate-limit.plugin.ts
@@ -1,0 +1,77 @@
+import { HeaderMap } from '@apollo/server'
+import type { ApolloServerPlugin, GraphQLRequestListener } from '@apollo/server'
+import { Plugin } from '@nestjs/apollo'
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { GraphQLSchemaHost } from '@nestjs/graphql'
+import { fromNodeHeaders } from 'better-auth/node'
+import { GraphQLError } from 'graphql'
+import {
+  fieldExtensionsEstimator,
+  getComplexity,
+  simpleEstimator,
+} from 'graphql-query-complexity/cjs'
+
+import { AuthService } from '@src/auth/auth.service'
+import { Context, IncomingMessageWithAuthCode } from '@src/graphql/graphql.context'
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+@Plugin()
+@Injectable()
+export class RateLimitPlugin implements ApolloServerPlugin<Context> {
+  constructor(
+    private gqlSchemaHost: GraphQLSchemaHost,
+    private rateLimitService: RateLimitService,
+    private authService: AuthService,
+    private configService: ConfigService,
+  ) {}
+
+  async requestDidStart(): Promise<GraphQLRequestListener<Context>> {
+    return {
+      didResolveOperation: async ({ request, document, contextValue }) => {
+        if (this.configService.get('rateLimit.enabled') === false) return
+
+        const complexity = getComplexity({
+          schema: this.gqlSchemaHost.schema,
+          operationName: request.operationName,
+          query: document,
+          variables: request.variables,
+          estimators: [fieldExtensionsEstimator(), simpleEstimator({ defaultComplexity: 1 })],
+        })
+
+        const req = contextValue.req
+        const session = await this.getSession(req)
+        const tier = session ? 'authenticated' : 'anonymous'
+        const identity = session ? `user:${session.user.id}` : `ip:${req?.ip}`
+
+        const { allowed, retryAfterMs } = await this.rateLimitService.consume(
+          identity,
+          complexity,
+          tier,
+        )
+        if (!allowed) {
+          const retryAfterSec = Math.ceil(retryAfterMs / 1000)
+          throw new GraphQLError('Rate limit exceeded', {
+            extensions: {
+              code: 'RATE_LIMITED',
+              retryAfterMs,
+              http: {
+                status: 429,
+                headers: new HeaderMap([['retry-after', String(retryAfterSec)]]),
+              },
+            },
+          })
+        }
+      },
+    }
+  }
+
+  private async getSession(req?: IncomingMessageWithAuthCode) {
+    if (!req?.headers.cookie) return null
+    try {
+      return await this.authService.api.getSession({ headers: fromNodeHeaders(req.headers) })
+    } catch {
+      return null
+    }
+  }
+}

--- a/apps/api/src/rate-limit/rate-limit.service.integration.spec.ts
+++ b/apps/api/src/rate-limit/rate-limit.service.integration.spec.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from 'crypto'
+
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import { createClient } from 'redis'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+import { RedisService } from '@src/common/redis.service'
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+const DRAGONFLY_URL =
+  process.env.DRAGONFLY_URL ?? process.env.TEST_DRAGONFLY_URL ?? 'redis://localhost:6379'
+
+async function isDragonflyReachable(): Promise<boolean> {
+  const client = createClient({ url: DRAGONFLY_URL, socket: { connectTimeout: 500 } })
+  try {
+    await client.connect()
+    await client.ping()
+    return true
+  } catch {
+    return false
+  } finally {
+    if (client.isOpen) await client.disconnect()
+  }
+}
+
+const dragonflyReachable = await isDragonflyReachable()
+
+describe.skipIf(!dragonflyReachable)('RateLimitService (integration)', () => {
+  let service: RateLimitService
+  let keyPrefix: string
+
+  const rateLimitConfig = {
+    anonymous: { capacity: 5, leakRatePerSec: 1 },
+    authenticated: { capacity: 50, leakRatePerSec: 10 },
+  }
+
+  beforeAll(async () => {
+    process.env.DRAGONFLY_URL = DRAGONFLY_URL
+    keyPrefix = `test:${randomUUID()}`
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitService,
+        RedisService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'rateLimit.anonymous') return rateLimitConfig.anonymous
+              if (key === 'rateLimit.authenticated') return rateLimitConfig.authenticated
+              return undefined
+            },
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get<RateLimitService>(RateLimitService)
+    const redis = module.get<RedisService>(RedisService)
+    await redis.onModuleInit()
+  })
+
+  // CL.THROTTLE's max_burst param yields a total usable capacity of max_burst + 1,
+  // so capacity + 1 consumes must succeed before the bucket is actually full.
+  test('rejects once burst capacity is exceeded, with a positive retryAfterMs', async () => {
+    const key = `${keyPrefix}:burst`
+
+    for (let i = 0; i <= rateLimitConfig.anonymous.capacity; i++) {
+      const result = await service.consume(key, 1, 'anonymous')
+      expect(result.allowed).toBe(true)
+    }
+
+    const overflow = await service.consume(key, 1, 'anonymous')
+    expect(overflow.allowed).toBe(false)
+    expect(overflow.retryAfterMs).toBeGreaterThan(0)
+  })
+
+  test('anonymous and authenticated tiers use independent buckets for the same identity', async () => {
+    const key = `${keyPrefix}:tiers`
+
+    for (let i = 0; i <= rateLimitConfig.anonymous.capacity; i++) {
+      await service.consume(key, 1, 'anonymous')
+    }
+    const anonOverflow = await service.consume(key, 1, 'anonymous')
+    expect(anonOverflow.allowed).toBe(false)
+
+    const authResult = await service.consume(key, 1, 'authenticated')
+    expect(authResult.allowed).toBe(true)
+  })
+
+  test('recovers after waiting out retryAfterMs', async () => {
+    const key = `${keyPrefix}:recovery`
+
+    for (let i = 0; i <= rateLimitConfig.anonymous.capacity; i++) {
+      await service.consume(key, 1, 'anonymous')
+    }
+    const overflow = await service.consume(key, 1, 'anonymous')
+    expect(overflow.allowed).toBe(false)
+
+    await new Promise((resolve) => setTimeout(resolve, overflow.retryAfterMs))
+
+    const recovered = await service.consume(key, 1, 'anonymous')
+    expect(recovered.allowed).toBe(true)
+  }, 15_000)
+})

--- a/apps/api/src/rate-limit/rate-limit.service.spec.ts
+++ b/apps/api/src/rate-limit/rate-limit.service.spec.ts
@@ -1,0 +1,95 @@
+import { ConfigService } from '@nestjs/config'
+import { Test, TestingModule } from '@nestjs/testing'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { RedisService } from '@src/common/redis.service'
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+describe('RateLimitService', () => {
+  let service: RateLimitService
+  let redis: { throttle: ReturnType<typeof vi.fn> }
+
+  const rateLimitConfig = {
+    anonymous: { capacity: 300, leakRatePerSec: 5 },
+    authenticated: { capacity: 3000, leakRatePerSec: 50 },
+  }
+
+  beforeEach(async () => {
+    redis = { throttle: vi.fn() }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RateLimitService,
+        { provide: RedisService, useValue: redis },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn((key: string) => {
+              if (key === 'rateLimit.anonymous') return rateLimitConfig.anonymous
+              if (key === 'rateLimit.authenticated') return rateLimitConfig.authenticated
+              return undefined
+            }),
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get<RateLimitService>(RateLimitService)
+  })
+
+  test('constructs the throttle key from a shortened tier label and identity', async () => {
+    redis.throttle.mockResolvedValue([0, 300, 299, -1, 60])
+
+    await service.consume('ip:1.2.3.4', 1, 'anonymous')
+
+    expect(redis.throttle).toHaveBeenCalledWith('rl:anon:ip:1.2.3.4', 300, 300, 60, 1)
+  })
+
+  test('derives period from capacity / leakRatePerSec per tier', async () => {
+    redis.throttle.mockResolvedValue([0, 3000, 2999, -1, 60])
+
+    await service.consume('user:42', 1, 'authenticated')
+
+    expect(redis.throttle).toHaveBeenCalledWith('rl:sess:user:42', 3000, 3000, 60, 1)
+  })
+
+  test('passes query complexity through as the throttle quantity', async () => {
+    redis.throttle.mockResolvedValue([0, 300, 250, -1, 60])
+
+    await service.consume('ip:1.2.3.4', 50, 'anonymous')
+
+    expect(redis.throttle).toHaveBeenCalledWith('rl:anon:ip:1.2.3.4', 300, 300, 60, 50)
+  })
+
+  test('floors cost at 1 so zero-complexity queries still consume from the bucket', async () => {
+    redis.throttle.mockResolvedValue([0, 300, 299, -1, 60])
+
+    await service.consume('ip:1.2.3.4', 0, 'anonymous')
+
+    expect(redis.throttle).toHaveBeenCalledWith('rl:anon:ip:1.2.3.4', 300, 300, 60, 1)
+  })
+
+  test('allows the request when under capacity', async () => {
+    redis.throttle.mockResolvedValue([0, 300, 299, -1, 60])
+
+    const result = await service.consume('ip:1.2.3.4', 1, 'anonymous')
+
+    expect(result).toEqual({ allowed: true, retryAfterMs: 0 })
+  })
+
+  test('rejects the request with retryAfterMs when over capacity', async () => {
+    redis.throttle.mockResolvedValue([1, 300, 0, 12, 60])
+
+    const result = await service.consume('ip:1.2.3.4', 1, 'anonymous')
+
+    expect(result).toEqual({ allowed: false, retryAfterMs: 12000 })
+  })
+
+  test('fails open when Redis/Dragonfly is unreachable', async () => {
+    redis.throttle.mockResolvedValue(null)
+
+    const result = await service.consume('ip:1.2.3.4', 1, 'anonymous')
+
+    expect(result).toEqual({ allowed: true, retryAfterMs: 0 })
+  })
+})

--- a/apps/api/src/rate-limit/rate-limit.service.ts
+++ b/apps/api/src/rate-limit/rate-limit.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+
+import { RedisService } from '@src/common/redis.service'
+
+export type RateLimitTier = 'anonymous' | 'authenticated'
+
+interface RateLimitResult {
+  allowed: boolean
+  retryAfterMs: number
+}
+
+const TIER_KEY_LABEL: Record<RateLimitTier, string> = {
+  anonymous: 'anon',
+  authenticated: 'sess',
+}
+
+@Injectable()
+export class RateLimitService {
+  constructor(
+    private redis: RedisService,
+    private config: ConfigService,
+  ) {}
+
+  async consume(key: string, cost: number, tier: RateLimitTier): Promise<RateLimitResult> {
+    const { capacity, leakRatePerSec } = this.config.get(`rateLimit.${tier}`)
+    const period = Math.max(1, Math.round(capacity / leakRatePerSec))
+
+    const result = await this.redis.throttle(
+      `rl:${TIER_KEY_LABEL[tier]}:${key}`,
+      capacity,
+      capacity,
+      period,
+      Math.max(1, cost),
+    )
+
+    if (result === null) return { allowed: true, retryAfterMs: 0 }
+    const [limited, , , retryAfterSec] = result
+    return { allowed: limited === 0, retryAfterMs: limited === 0 ? 0 : retryAfterSec * 1000 }
+  }
+}

--- a/apps/api/test/app-test.module.ts
+++ b/apps/api/test/app-test.module.ts
@@ -38,7 +38,8 @@ if (dotenv) {
     ConfigModule.forRoot({
       isGlobal: true,
       ignoreEnvFile: true,
-      load: [config],
+      // Disable rate limiting in tests
+      load: [config, () => ({ rateLimit: { enabled: false } })],
     }),
     ClsModule.forRoot({
       global: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       graphql:
         specifier: 16.11.0
         version: 16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8)
+      graphql-query-complexity:
+        specifier: ^1.1.1
+        version: 1.1.1(graphql@16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8))
       graphql-scalars:
         specifier: ^1.24.1
         version: 1.24.1(graphql@16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8))
@@ -9489,6 +9492,11 @@ packages:
       cosmiconfig-toml-loader:
         optional: true
 
+  graphql-query-complexity@1.1.1:
+    resolution: {integrity: sha512-q0u1yrPYdEYnhEL4x6xeEoOHdHUV4hISrI/uDFhOaxLvIN60RqlzV3kW6N0f+0pygGM9wjskl1cD5/55G+TPmw==}
+    peerDependencies:
+      graphql: 16.11.0
+
   graphql-scalars@1.24.1:
     resolution: {integrity: sha512-3L553TMPh3YpHQM4x9G4tXcyD+AX8QQOYA6tUn1nrNiWEXE0JfAnWdjoe3WGxRuGjnZrzvHDz62q8S+sSGXXwA==}
     engines: {node: '>=10'}
@@ -10338,6 +10346,10 @@ packages:
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -23548,6 +23560,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  graphql-query-complexity@1.1.1(graphql@16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8)):
+    dependencies:
+      graphql: 16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8)
+      lodash.get: 4.4.2
+
   graphql-scalars@1.24.1(graphql@16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8)):
     dependencies:
       graphql: 16.11.0(patch_hash=5d7b99c90cd936c0300d91b318f94e48d710b883b2639c69683463cd1f72fac8)
@@ -24360,6 +24377,8 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.defaults@4.2.0: {}
+
+  lodash.get@4.4.2: {}
 
   lodash.includes@4.3.0: {}
 


### PR DESCRIPTION
#100 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add complexity-based rate limiting to the GraphQL API using Redis/Dragonfly. Requests are charged by query complexity and limited per IP or user; exceeding the limit returns 429 with Retry-After.

- **New Features**
  - Compute cost with `graphql-query-complexity`.
  - Separate buckets: anonymous (IP) and authenticated (session user).
  - Enforce via Redis `CL.THROTTLE`; fails open if Redis is down.
  - Configurable by env; can be disabled via `RATE_LIMIT_ENABLED=false`.
  - Set `trust proxy` to read real client IP behind a proxy.

- **Migration**
  - Ensure Dragonfly/Redis is reachable via `DRAGONFLY_URL`.
  - Optional envs: `RATE_LIMIT_ANON_CAPACITY`, `RATE_LIMIT_ANON_LEAK_RATE`, `RATE_LIMIT_AUTH_CAPACITY`, `RATE_LIMIT_AUTH_LEAK_RATE`.
  - If behind a proxy, forward `X-Forwarded-For`; the app now uses `app.set('trust proxy', 1)`.

<sup>Written for commit 32eefd8e628ecf6adc2f44d4d06746fd0f32fa81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

