### PR TITLE
science: fix forms not rendering in prod

### DIFF
--- a/packages/ui/app/components/model/Form.vue
+++ b/packages/ui/app/components/model/Form.vue
@@ -102,7 +102,7 @@ const uiSchema = computed(() => {
   return null
 })
 
-const createData = ref<object | null>(null)
+const createData = ref<object>({})
 const updateData = ref<object | null>(null)
 const changeStatus = ref<ChangeStatus | null>(null)
 

--- a/packages/ui/app/components/model/FormDirect.vue
+++ b/packages/ui/app/components/model/FormDirect.vue
@@ -83,7 +83,7 @@ const uiSchema = computed(() => {
   return null
 })
 
-const createData = ref<object | null>(null)
+const createData = ref<object>({})
 const updateData = ref<object | null>(null)
 const editQuery = graphql(`
   query DirectGetEdit($id: ID!, $entityName: String!) {

--- a/packages/ui/app/forms/array/ArrayListRenderer.vue
+++ b/packages/ui/app/forms/array/ArrayListRenderer.vue
@@ -63,17 +63,10 @@
 </template>
 
 <script lang="ts">
-import type {
-  JsonFormsRendererRegistryEntry,
-  ControlElement,
-  JsonSchema,
-  JsonFormsSubStates,
-} from '@jsonforms/core'
+import type { ControlElement, JsonSchema, JsonFormsSubStates } from '@jsonforms/core'
 import {
   composePaths,
   createDefaultValue,
-  rankWith,
-  schemaTypeIs,
   Resolve,
   arrayDefaultTranslations,
   getArrayTranslations,
@@ -88,7 +81,7 @@ import { useVanillaArrayControl } from '../util'
 import ArrayListElement from './ArrayListElement.vue'
 import ArrayListRefElement from './ArrayListRefElement.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'ArrayListRenderer',
   components: {
     ArrayListElement,
@@ -156,11 +149,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, schemaTypeIs('array')),
-}
 </script>

--- a/packages/ui/app/forms/array/index.ts
+++ b/packages/ui/app/forms/array/index.ts
@@ -1,5 +1,10 @@
-import { entry as arrayListRendererEntry } from './ArrayListRenderer.vue'
+import type { JsonFormsRendererRegistryEntry } from '@jsonforms/core'
+import { rankWith, schemaTypeIs } from '@jsonforms/core'
 
-export { default as ArrayListRenderer } from './ArrayListRenderer.vue'
+import ArrayListRenderer from './ArrayListRenderer.vue'
 
-export const arrayRenderers = [arrayListRendererEntry]
+export { ArrayListRenderer }
+
+export const arrayRenderers: JsonFormsRendererRegistryEntry[] = [
+  { renderer: ArrayListRenderer, tester: rankWith(2, schemaTypeIs('array')) },
+]

--- a/packages/ui/app/forms/complex/EnumArrayRenderer.vue
+++ b/packages/ui/app/forms/complex/EnumArrayRenderer.vue
@@ -17,22 +17,14 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry, JsonSchema } from '@jsonforms/core'
-import {
-  rankWith,
-  uiTypeIs,
-  and,
-  schemaMatches,
-  hasType,
-  schemaSubPathMatches,
-} from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsMultiEnumControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
 
 import { useVanillaArrayControl } from '../util'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'EnumArrayRenderer',
   props: {
     ...rendererProps<ControlElement>(),
@@ -57,35 +49,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-const hasOneOfItems = (schema: JsonSchema): boolean =>
-  schema.oneOf !== undefined &&
-  schema.oneOf.length > 0 &&
-  (schema.oneOf as JsonSchema[]).every((entry: JsonSchema) => {
-    return entry.const !== undefined
-  })
-
-const hasEnumItems = (schema: JsonSchema): boolean =>
-  schema.type === 'string' && schema.enum !== undefined
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(
-    5,
-    and(
-      uiTypeIs('Control'),
-      and(
-        schemaMatches(
-          (schema) =>
-            hasType(schema, 'array') && !Array.isArray(schema.items) && schema.uniqueItems === true,
-        ),
-        schemaSubPathMatches('items', (schema) => {
-          return hasOneOfItems(schema) || hasEnumItems(schema)
-        }),
-      ),
-    ),
-  ),
-}
 </script>

--- a/packages/ui/app/forms/complex/ObjectRenderer.vue
+++ b/packages/ui/app/forms/complex/ObjectRenderer.vue
@@ -13,13 +13,8 @@
 </template>
 
 <script lang="ts">
-import type {
-  JsonFormsRendererRegistryEntry,
-  ControlElement,
-  GroupLayout,
-  UISchemaElement,
-} from '@jsonforms/core'
-import { rankWith, Generate, findUISchema, isObjectControl } from '@jsonforms/core'
+import type { ControlElement, GroupLayout, UISchemaElement } from '@jsonforms/core'
+import { Generate, findUISchema } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { DispatchRenderer, rendererProps, useJsonFormsControlWithDetail } from '@jsonforms/vue'
 import { isEmpty } from 'lodash-es'
@@ -27,7 +22,7 @@ import { defineComponent } from 'vue'
 
 import { useVanillaControl } from '../util'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'ObjectRenderer',
   components: {
     DispatchRenderer,
@@ -73,11 +68,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isObjectControl),
-}
 </script>

--- a/packages/ui/app/forms/complex/OneOfRenderer.vue
+++ b/packages/ui/app/forms/complex/OneOfRenderer.vue
@@ -68,7 +68,6 @@
 import type {
   CombinatorSubSchemaRenderInfo,
   ControlElement,
-  JsonFormsRendererRegistryEntry,
   JsonFormsSubStates,
 } from '@jsonforms/core'
 import {
@@ -77,8 +76,6 @@ import {
   createDefaultValue,
   defaultJsonFormsI18nState,
   getCombinatorTranslations,
-  isOneOfControl,
-  rankWith,
 } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { DispatchRenderer, rendererProps, useJsonFormsOneOfControl } from '@jsonforms/vue'
@@ -89,7 +86,7 @@ import { ControlWrapper } from '../controls'
 import { useVanillaControl } from '../util'
 import CombinatorProperties from './components/CombinatorProperties.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'OneOfRenderer',
   components: {
     ControlWrapper,
@@ -197,11 +194,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(3, isOneOfControl),
-}
 </script>

--- a/packages/ui/app/forms/complex/ReferenceRenderer.vue
+++ b/packages/ui/app/forms/complex/ReferenceRenderer.vue
@@ -142,8 +142,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, and, uiTypeIs, schemaMatches, schemaTypeIs } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { watchDebounced } from '@vueuse/core'
@@ -155,18 +154,7 @@ import { SearchType } from '~/gql/graphql'
 import { ControlWrapper } from '../controls'
 import { useVanillaControl } from '../util'
 
-const supportedTypes = new Set([
-  'Category',
-  'Item',
-  'Variant',
-  'Component',
-  'Place',
-  'Region',
-  'Org',
-  'Material',
-])
-
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'ReferenceRenderer',
   components: {
     ControlWrapper,
@@ -264,21 +252,4 @@ const controlRenderer = defineComponent({
     )
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(
-    2,
-    and(
-      uiTypeIs('Control'),
-      schemaMatches((schema) => {
-        const sch = schema as { $id: string }
-        return Object.prototype.hasOwnProperty.call(schema, '$id') && supportedTypes.has(sch.$id)
-      }),
-      schemaTypeIs('string'),
-    ),
-  ),
-}
 </script>

--- a/packages/ui/app/forms/complex/TranslatedFieldRenderer.vue
+++ b/packages/ui/app/forms/complex/TranslatedFieldRenderer.vue
@@ -161,8 +161,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry, JsonSchema } from '@jsonforms/core'
-import { rankWith, and, uiTypeIs, schemaTypeIs, schemaMatches } from '@jsonforms/core'
+import type { ControlElement, JsonSchema } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsArrayControl, useJsonFormsControl } from '@jsonforms/vue'
 import { ChevronDown, Plus } from '@lucide/vue'
@@ -185,14 +184,6 @@ interface TranslationEntry {
   lang: string
   text?: string
   auto?: boolean
-}
-
-const isTranslatedArray = (schema: JsonSchema): boolean => {
-  if (schema.type !== 'array') return false
-  const items = schema.items
-  if (!items || Array.isArray(items)) return false
-  const langProp = (items as JsonSchema).properties?.lang as JsonSchema | undefined
-  return langProp?.['$ref'] === '#/$defs/lang'
 }
 
 function getLabel(code: string): string {
@@ -334,7 +325,7 @@ function useHandlers(ctx: HandlersContext) {
   }
 }
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'TranslatedFieldRenderer',
   components: { ChevronDown, Plus, PopoverRoot, PopoverTrigger, PopoverPortal, PopoverContent },
   props: {
@@ -447,14 +438,4 @@ const controlRenderer = defineComponent({
     }
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(
-    4,
-    and(uiTypeIs('Control'), schemaTypeIs('array'), schemaMatches(isTranslatedArray)),
-  ),
-}
 </script>

--- a/packages/ui/app/forms/complex/index.ts
+++ b/packages/ui/app/forms/complex/index.ts
@@ -1,19 +1,104 @@
-import { entry as enumArrayRendererEntry } from './EnumArrayRenderer.vue'
-import { entry as objectRendererEntry } from './ObjectRenderer.vue'
-import { entry as oneOfRendererEntry } from './OneOfRenderer.vue'
-import { entry as referenceRendererEntry } from './ReferenceRenderer.vue'
-import { entry as translatedFieldRendererEntry } from './TranslatedFieldRenderer.vue'
+import type { JsonFormsRendererRegistryEntry, JsonSchema } from '@jsonforms/core'
+import {
+  and,
+  hasType,
+  isObjectControl,
+  isOneOfControl,
+  rankWith,
+  schemaMatches,
+  schemaSubPathMatches,
+  schemaTypeIs,
+  uiTypeIs,
+} from '@jsonforms/core'
 
-export { default as ObjectRenderer } from './ObjectRenderer.vue'
-export { default as OneOfRenderer } from './OneOfRenderer.vue'
-export { default as EnumArrayRenderer } from './EnumArrayRenderer.vue'
-export { default as ReferenceRenderer } from './ReferenceRenderer.vue'
-export { default as TranslatedFieldRenderer } from './TranslatedFieldRenderer.vue'
+import EnumArrayRenderer from './EnumArrayRenderer.vue'
+import ObjectRenderer from './ObjectRenderer.vue'
+import OneOfRenderer from './OneOfRenderer.vue'
+import ReferenceRenderer from './ReferenceRenderer.vue'
+import TranslatedFieldRenderer from './TranslatedFieldRenderer.vue'
 
-export const complexRenderers = [
-  objectRendererEntry,
-  oneOfRendererEntry,
-  enumArrayRendererEntry,
-  referenceRendererEntry,
-  translatedFieldRendererEntry,
+export {
+  ObjectRenderer,
+  OneOfRenderer,
+  EnumArrayRenderer,
+  ReferenceRenderer,
+  TranslatedFieldRenderer,
+}
+
+const hasOneOfItems = (schema: JsonSchema): boolean =>
+  schema.oneOf !== undefined &&
+  schema.oneOf.length > 0 &&
+  (schema.oneOf as JsonSchema[]).every((entry: JsonSchema) => {
+    return entry.const !== undefined
+  })
+
+const hasEnumItems = (schema: JsonSchema): boolean =>
+  schema.type === 'string' && schema.enum !== undefined
+
+const supportedReferenceTypes = new Set([
+  'Category',
+  'Item',
+  'Variant',
+  'Component',
+  'Place',
+  'Region',
+  'Org',
+  'Material',
+])
+
+const isTranslatedArray = (schema: JsonSchema): boolean => {
+  if (schema.type !== 'array') return false
+  const items = schema.items
+  if (!items || Array.isArray(items)) return false
+  const langProp = (items as JsonSchema).properties?.lang as JsonSchema | undefined
+  return langProp?.['$ref'] === '#/$defs/lang'
+}
+
+export const complexRenderers: JsonFormsRendererRegistryEntry[] = [
+  { renderer: ObjectRenderer, tester: rankWith(2, isObjectControl) },
+  { renderer: OneOfRenderer, tester: rankWith(3, isOneOfControl) },
+  {
+    renderer: EnumArrayRenderer,
+    tester: rankWith(
+      5,
+      and(
+        uiTypeIs('Control'),
+        and(
+          schemaMatches(
+            (schema) =>
+              hasType(schema, 'array') &&
+              !Array.isArray(schema.items) &&
+              schema.uniqueItems === true,
+          ),
+          schemaSubPathMatches('items', (schema) => {
+            return hasOneOfItems(schema) || hasEnumItems(schema)
+          }),
+        ),
+      ),
+    ),
+  },
+  {
+    renderer: ReferenceRenderer,
+    tester: rankWith(
+      2,
+      and(
+        uiTypeIs('Control'),
+        schemaMatches((schema) => {
+          const sch = schema as { $id: string }
+          return (
+            Object.prototype.hasOwnProperty.call(schema, '$id') &&
+            supportedReferenceTypes.has(sch.$id)
+          )
+        }),
+        schemaTypeIs('string'),
+      ),
+    ),
+  },
+  {
+    renderer: TranslatedFieldRenderer,
+    tester: rankWith(
+      4,
+      and(uiTypeIs('Control'), schemaTypeIs('array'), schemaMatches(isTranslatedArray)),
+    ),
+  },
 ]

--- a/packages/ui/app/forms/controls/BooleanControlRenderer.vue
+++ b/packages/ui/app/forms/controls/BooleanControlRenderer.vue
@@ -21,8 +21,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isBooleanControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -31,7 +30,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'BooleanControlRenderer',
   components: {
     ControlWrapper,
@@ -43,11 +42,4 @@ const controlRenderer = defineComponent({
     return useVanillaControl(useJsonFormsControl(props), (target) => target.checked)
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isBooleanControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/DateControlRenderer.vue
+++ b/packages/ui/app/forms/controls/DateControlRenderer.vue
@@ -21,8 +21,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isDateControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -31,7 +30,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'DateControlRenderer',
   components: {
     ControlWrapper,
@@ -43,11 +42,4 @@ const controlRenderer = defineComponent({
     return useVanillaControl(useJsonFormsControl(props), (target) => target.value || undefined)
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isDateControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/DateTimeControlRenderer.vue
+++ b/packages/ui/app/forms/controls/DateTimeControlRenderer.vue
@@ -21,8 +21,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isDateTimeControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -35,7 +34,7 @@ const toISOString = (inputDateTime: string) => {
   return inputDateTime === '' ? undefined : inputDateTime + ':00.000Z'
 }
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'DatetimeControlRenderer',
   components: {
     ControlWrapper,
@@ -52,11 +51,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isDateTimeControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/EnumControlRenderer.vue
+++ b/packages/ui/app/forms/controls/EnumControlRenderer.vue
@@ -38,8 +38,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isEnumControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsEnumControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -48,7 +47,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'EnumControlRenderer',
   components: {
     ControlWrapper,
@@ -62,11 +61,4 @@ const controlRenderer = defineComponent({
     )
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isEnumControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/EnumOneOfControlRenderer.vue
+++ b/packages/ui/app/forms/controls/EnumOneOfControlRenderer.vue
@@ -37,8 +37,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isOneOfEnumControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsOneOfEnumControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -47,7 +46,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'EnumOneofControlRenderer',
   components: {
     ControlWrapper,
@@ -61,11 +60,4 @@ const controlRenderer = defineComponent({
     )
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(5, isOneOfEnumControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/ImageControlRenderer.vue
+++ b/packages/ui/app/forms/controls/ImageControlRenderer.vue
@@ -60,8 +60,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, and, uiTypeIs, or, formatIs, optionIs } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { watchDebounced } from '@vueuse/core'
@@ -71,7 +70,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'ImageControlRenderer',
   components: {
     ControlWrapper,
@@ -119,11 +118,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, and(uiTypeIs('Control'), or(formatIs('uri'), optionIs('format', 'uri')))),
-}
 </script>

--- a/packages/ui/app/forms/controls/IntegerControlRenderer.vue
+++ b/packages/ui/app/forms/controls/IntegerControlRenderer.vue
@@ -22,8 +22,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isIntegerControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -32,7 +31,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'IntegerControlRenderer',
   components: {
     ControlWrapper,
@@ -46,11 +45,4 @@ const controlRenderer = defineComponent({
     )
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isIntegerControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/MultiStringControlRenderer.vue
+++ b/packages/ui/app/forms/controls/MultiStringControlRenderer.vue
@@ -20,8 +20,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isStringControl, isMultiLineControl, and } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -30,7 +29,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'MultiStringControlRenderer',
   components: {
     ControlWrapper,
@@ -42,11 +41,4 @@ const controlRenderer = defineComponent({
     return useVanillaControl(useJsonFormsControl(props), (target) => target.value || undefined)
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, and(isStringControl, isMultiLineControl)),
-}
 </script>

--- a/packages/ui/app/forms/controls/NumberControlRenderer.vue
+++ b/packages/ui/app/forms/controls/NumberControlRenderer.vue
@@ -22,8 +22,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isNumberControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -32,7 +31,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'NumberControlRenderer',
   components: {
     ControlWrapper,
@@ -53,11 +52,4 @@ const controlRenderer = defineComponent({
     },
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isNumberControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/StringControlRenderer.vue
+++ b/packages/ui/app/forms/controls/StringControlRenderer.vue
@@ -20,8 +20,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isStringControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -30,7 +29,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'StringControlRenderer',
   components: {
     ControlWrapper,
@@ -42,11 +41,4 @@ const controlRenderer = defineComponent({
     return useVanillaControl(useJsonFormsControl(props), (target) => target.value || undefined)
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(1, isStringControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/TimeControlRenderer.vue
+++ b/packages/ui/app/forms/controls/TimeControlRenderer.vue
@@ -21,8 +21,7 @@
 </template>
 
 <script lang="ts">
-import type { ControlElement, JsonFormsRendererRegistryEntry } from '@jsonforms/core'
-import { rankWith, isTimeControl } from '@jsonforms/core'
+import type { ControlElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsControl } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
@@ -31,7 +30,7 @@ import { useVanillaControl } from '../util'
 // eslint-disable-next-line import/no-named-default
 import { default as ControlWrapper } from './ControlWrapper.vue'
 
-const controlRenderer = defineComponent({
+export default defineComponent({
   name: 'TimeControlRenderer',
   components: {
     ControlWrapper,
@@ -43,11 +42,4 @@ const controlRenderer = defineComponent({
     return useVanillaControl(useJsonFormsControl(props), (target) => target.value || undefined)
   },
 })
-
-export default controlRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: controlRenderer,
-  tester: rankWith(2, isTimeControl),
-}
 </script>

--- a/packages/ui/app/forms/controls/index.ts
+++ b/packages/ui/app/forms/controls/index.ts
@@ -1,38 +1,66 @@
-import { entry as booleanControlRendererEntry } from './BooleanControlRenderer.vue'
-import { entry as dateControlRendererEntry } from './DateControlRenderer.vue'
-import { entry as dateTimeControlRendererEntry } from './DateTimeControlRenderer.vue'
-import { entry as enumControlRendererEntry } from './EnumControlRenderer.vue'
-import { entry as oneOfEnumControlRendererEntry } from './EnumOneOfControlRenderer.vue'
-import { entry as imageControlRendererEntry } from './ImageControlRenderer.vue'
-import { entry as integerControlRendererEntry } from './IntegerControlRenderer.vue'
-import { entry as multiStringControlRendererEntry } from './MultiStringControlRenderer.vue'
-import { entry as numberControlRendererEntry } from './NumberControlRenderer.vue'
-import { entry as stringControlRendererEntry } from './StringControlRenderer.vue'
-import { entry as timeControlRendererEntry } from './TimeControlRenderer.vue'
+import type { JsonFormsRendererRegistryEntry } from '@jsonforms/core'
+import {
+  and,
+  formatIs,
+  isBooleanControl,
+  isDateControl,
+  isDateTimeControl,
+  isEnumControl,
+  isIntegerControl,
+  isMultiLineControl,
+  isNumberControl,
+  isOneOfEnumControl,
+  isStringControl,
+  isTimeControl,
+  optionIs,
+  or,
+  rankWith,
+  uiTypeIs,
+} from '@jsonforms/core'
+
+import BooleanControlRenderer from './BooleanControlRenderer.vue'
+import DateControlRenderer from './DateControlRenderer.vue'
+import DateTimeControlRenderer from './DateTimeControlRenderer.vue'
+import EnumControlRenderer from './EnumControlRenderer.vue'
+import EnumOneOfControlRenderer from './EnumOneOfControlRenderer.vue'
+import ImageControlRenderer from './ImageControlRenderer.vue'
+import IntegerControlRenderer from './IntegerControlRenderer.vue'
+import MultiStringControlRenderer from './MultiStringControlRenderer.vue'
+import NumberControlRenderer from './NumberControlRenderer.vue'
+import StringControlRenderer from './StringControlRenderer.vue'
+import TimeControlRenderer from './TimeControlRenderer.vue'
 
 export { default as ControlWrapper } from './ControlWrapper.vue'
-export { default as StringControlRenderer } from './StringControlRenderer.vue'
-export { default as MultiStringControlRenderer } from './MultiStringControlRenderer.vue'
-export { default as NumberControlRenderer } from './NumberControlRenderer.vue'
-export { default as IntegerControlRenderer } from './IntegerControlRenderer.vue'
-export { default as EnumControlRenderer } from './EnumControlRenderer.vue'
-export { default as oneOfEnumControlRenderer } from './EnumOneOfControlRenderer.vue'
-export { default as DateControlRenderer } from './DateControlRenderer.vue'
-export { default as DateTimeControlRenderer } from './DateTimeControlRenderer.vue'
-export { default as TimeControlRenderer } from './TimeControlRenderer.vue'
-export { default as BooleanControlRenderer } from './BooleanControlRenderer.vue'
-export { default as ImageControlRenderer } from './ImageControlRenderer.vue'
+export {
+  StringControlRenderer,
+  MultiStringControlRenderer,
+  NumberControlRenderer,
+  IntegerControlRenderer,
+  EnumControlRenderer,
+  EnumOneOfControlRenderer as oneOfEnumControlRenderer,
+  DateControlRenderer,
+  DateTimeControlRenderer,
+  TimeControlRenderer,
+  BooleanControlRenderer,
+  ImageControlRenderer,
+}
 
-export const controlRenderers = [
-  stringControlRendererEntry,
-  multiStringControlRendererEntry,
-  numberControlRendererEntry,
-  integerControlRendererEntry,
-  enumControlRendererEntry,
-  oneOfEnumControlRendererEntry,
-  dateControlRendererEntry,
-  dateTimeControlRendererEntry,
-  timeControlRendererEntry,
-  booleanControlRendererEntry,
-  imageControlRendererEntry,
+export const controlRenderers: JsonFormsRendererRegistryEntry[] = [
+  { renderer: StringControlRenderer, tester: rankWith(1, isStringControl) },
+  {
+    renderer: MultiStringControlRenderer,
+    tester: rankWith(2, and(isStringControl, isMultiLineControl)),
+  },
+  { renderer: NumberControlRenderer, tester: rankWith(1, isNumberControl) },
+  { renderer: IntegerControlRenderer, tester: rankWith(1, isIntegerControl) },
+  { renderer: EnumControlRenderer, tester: rankWith(2, isEnumControl) },
+  { renderer: EnumOneOfControlRenderer, tester: rankWith(5, isOneOfEnumControl) },
+  { renderer: DateControlRenderer, tester: rankWith(2, isDateControl) },
+  { renderer: DateTimeControlRenderer, tester: rankWith(2, isDateTimeControl) },
+  { renderer: TimeControlRenderer, tester: rankWith(2, isTimeControl) },
+  { renderer: BooleanControlRenderer, tester: rankWith(1, isBooleanControl) },
+  {
+    renderer: ImageControlRenderer,
+    tester: rankWith(2, and(uiTypeIs('Control'), or(formatIs('uri'), optionIs('format', 'uri')))),
+  },
 ]

--- a/packages/ui/app/forms/label/LabelRenderer.vue
+++ b/packages/ui/app/forms/label/LabelRenderer.vue
@@ -5,15 +5,14 @@
 </template>
 
 <script lang="ts">
-import type { JsonFormsRendererRegistryEntry, LabelElement } from '@jsonforms/core'
-import { rankWith, uiTypeIs } from '@jsonforms/core'
+import type { LabelElement } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { rendererProps, useJsonFormsLabel } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
 
 import { useVanillaLabel } from '../util'
 
-const labelRenderer = defineComponent({
+export default defineComponent({
   name: 'LabelRenderer',
   props: {
     ...rendererProps<LabelElement>(),
@@ -22,11 +21,4 @@ const labelRenderer = defineComponent({
     return useVanillaLabel(useJsonFormsLabel(props))
   },
 })
-
-export default labelRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: labelRenderer,
-  tester: rankWith(1, uiTypeIs('Label')),
-}
 </script>

--- a/packages/ui/app/forms/label/index.ts
+++ b/packages/ui/app/forms/label/index.ts
@@ -1,5 +1,10 @@
-import { entry as labelRendererEntry } from './LabelRenderer.vue'
+import type { JsonFormsRendererRegistryEntry } from '@jsonforms/core'
+import { rankWith, uiTypeIs } from '@jsonforms/core'
 
-export { default as LabelRenderer } from './LabelRenderer.vue'
+import LabelRenderer from './LabelRenderer.vue'
 
-export const labelRenderers = [labelRendererEntry]
+export { LabelRenderer }
+
+export const labelRenderers: JsonFormsRendererRegistryEntry[] = [
+  { renderer: LabelRenderer, tester: rankWith(1, uiTypeIs('Label')) },
+]

--- a/packages/ui/app/forms/layouts/CategorizationRenderer.vue
+++ b/packages/ui/app/forms/layouts/CategorizationRenderer.vue
@@ -28,8 +28,7 @@
 </template>
 
 <script lang="ts">
-import type { JsonFormsRendererRegistryEntry, Layout } from '@jsonforms/core'
-import { and, categorizationHasCategory, isCategorization, rankWith } from '@jsonforms/core'
+import type { Layout } from '@jsonforms/core'
 import {
   DispatchRenderer,
   rendererProps,
@@ -40,7 +39,7 @@ import { defineComponent } from 'vue'
 
 import { useVanillaLayout } from '../util'
 
-const layoutRenderer = defineComponent({
+export default defineComponent({
   name: 'CategorizationRenderer',
   components: {
     DispatchRenderer,
@@ -57,10 +56,4 @@ const layoutRenderer = defineComponent({
     }
   },
 })
-
-export default layoutRenderer
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, and(isCategorization, categorizationHasCategory)),
-}
 </script>

--- a/packages/ui/app/forms/layouts/CategorizationStepperRenderer.vue
+++ b/packages/ui/app/forms/layouts/CategorizationStepperRenderer.vue
@@ -57,14 +57,7 @@
 </template>
 
 <script lang="ts">
-import type { JsonFormsRendererRegistryEntry, Layout } from '@jsonforms/core'
-import {
-  and,
-  categorizationHasCategory,
-  isCategorization,
-  optionIs,
-  rankWith,
-} from '@jsonforms/core'
+import type { Layout } from '@jsonforms/core'
 import {
   DispatchRenderer,
   rendererProps,
@@ -75,7 +68,7 @@ import { defineComponent } from 'vue'
 
 import { useVanillaLayout } from '../util'
 
-const layoutRenderer = defineComponent({
+export default defineComponent({
   name: 'CategorizationStepperRenderer',
   components: {
     DispatchRenderer,
@@ -97,13 +90,4 @@ const layoutRenderer = defineComponent({
     },
   },
 })
-
-export default layoutRenderer
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(
-    3,
-    and(isCategorization, categorizationHasCategory, optionIs('variant', 'stepper')),
-  ),
-}
 </script>

--- a/packages/ui/app/forms/layouts/GroupRenderer.vue
+++ b/packages/ui/app/forms/layouts/GroupRenderer.vue
@@ -21,15 +21,14 @@
 </template>
 
 <script lang="ts">
-import type { JsonFormsRendererRegistryEntry, Layout } from '@jsonforms/core'
-import { rankWith, and, isLayout, uiTypeIs } from '@jsonforms/core'
+import type { Layout } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { DispatchRenderer, rendererProps, useJsonFormsLayout } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
 
 import { useVanillaLayout } from '../util'
 
-const layoutRenderer = defineComponent({
+export default defineComponent({
   name: 'GroupRenderer',
   components: {
     DispatchRenderer,
@@ -41,11 +40,4 @@ const layoutRenderer = defineComponent({
     return useVanillaLayout(useJsonFormsLayout(props))
   },
 })
-
-export default layoutRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(2, and(isLayout, uiTypeIs('Group'))),
-}
 </script>

--- a/packages/ui/app/forms/layouts/LayoutRenderer.vue
+++ b/packages/ui/app/forms/layouts/LayoutRenderer.vue
@@ -18,15 +18,14 @@
 </template>
 
 <script lang="ts">
-import type { JsonFormsRendererRegistryEntry, Layout } from '@jsonforms/core'
-import { isLayout, rankWith } from '@jsonforms/core'
+import type { Layout } from '@jsonforms/core'
 import type { RendererProps } from '@jsonforms/vue'
 import { DispatchRenderer, rendererProps, useJsonFormsLayout } from '@jsonforms/vue'
 import { defineComponent } from 'vue'
 
 import { useVanillaLayout } from '../util'
 
-const layoutRenderer = defineComponent({
+export default defineComponent({
   name: 'LayoutRenderer',
   components: {
     DispatchRenderer,
@@ -46,11 +45,4 @@ const layoutRenderer = defineComponent({
     },
   },
 })
-
-export default layoutRenderer
-
-export const entry: JsonFormsRendererRegistryEntry = {
-  renderer: layoutRenderer,
-  tester: rankWith(1, isLayout),
-}
 </script>

--- a/packages/ui/app/forms/layouts/index.ts
+++ b/packages/ui/app/forms/layouts/index.ts
@@ -1,16 +1,33 @@
-import { entry as categorizationEntry } from './CategorizationRenderer.vue'
-import { entry as categorizationStepperEntry } from './CategorizationStepperRenderer.vue'
-import { entry as groupRendererEntry } from './GroupRenderer.vue'
-import { entry as layoutRendererEntry } from './LayoutRenderer.vue'
+import type { JsonFormsRendererRegistryEntry } from '@jsonforms/core'
+import {
+  and,
+  categorizationHasCategory,
+  isCategorization,
+  isLayout,
+  optionIs,
+  rankWith,
+  uiTypeIs,
+} from '@jsonforms/core'
 
-export { default as LayoutRenderer } from './LayoutRenderer.vue'
-export { default as GroupRenderer } from './GroupRenderer.vue'
-export { default as CategorizationRenderer } from './CategorizationRenderer.vue'
-export { default as CategorizationStepperRenderer } from './CategorizationStepperRenderer.vue'
+import CategorizationRenderer from './CategorizationRenderer.vue'
+import CategorizationStepperRenderer from './CategorizationStepperRenderer.vue'
+import GroupRenderer from './GroupRenderer.vue'
+import LayoutRenderer from './LayoutRenderer.vue'
 
-export const layoutRenderers = [
-  layoutRendererEntry,
-  groupRendererEntry,
-  categorizationEntry,
-  categorizationStepperEntry,
+export { LayoutRenderer, GroupRenderer, CategorizationRenderer, CategorizationStepperRenderer }
+
+export const layoutRenderers: JsonFormsRendererRegistryEntry[] = [
+  { renderer: LayoutRenderer, tester: rankWith(1, isLayout) },
+  { renderer: GroupRenderer, tester: rankWith(2, and(isLayout, uiTypeIs('Group'))) },
+  {
+    renderer: CategorizationRenderer,
+    tester: rankWith(2, and(isCategorization, categorizationHasCategory)),
+  },
+  {
+    renderer: CategorizationStepperRenderer,
+    tester: rankWith(
+      3,
+      and(isCategorization, categorizationHasCategory, optionIs('variant', 'stepper')),
+    ),
+  },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken form rendering in production by centralizing `@jsonforms` renderer registration and exporting components correctly. Also initializes create form state to an empty object to prevent null issues on first render.

- **Bug Fixes**
  - Moved all renderer testers to `index.ts` files (`array`, `complex`, `controls`, `label`, `layouts`) using `JsonFormsRendererRegistryEntry[]` from `@jsonforms/core`.
  - Removed per-component `entry` exports; components now use `export default defineComponent(...)` for reliable production bundling.
  - Set `createData` to `{}` in `Form.vue` and `FormDirect.vue` to avoid null-bound inputs and ensure fields render immediately.

<sup>Written for commit 44bd020310f061ccb9d9c52a4ca3b7d113790e12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

