### PR TITLE
api: Index rank order and default to relevancy order

### DIFF
--- a/apps/api/src/common/transform.ts
+++ b/apps/api/src/common/transform.ts
@@ -9,7 +9,7 @@ import type {
   QueryOrderMap,
   Ref,
 } from '@mikro-orm/core'
-import { EntityManager } from '@mikro-orm/postgresql'
+import { EntityManager, raw } from '@mikro-orm/postgresql'
 import { Injectable } from '@nestjs/common'
 import { plainToInstance } from 'class-transformer'
 import type { ClassConstructor, ClassTransformOptions, TransformFnParams } from 'class-transformer'
@@ -100,6 +100,7 @@ export class TransformService {
     const args = plainToInstance(cls, result.data)
     const where: ObjectQuery<any> = {}
     const orderByField = args.orderBy()[0] || 'id'
+    const isRelevance = orderByField === 'relevance'
     let decoded = ''
     if (args.after || args.before) {
       try {
@@ -109,10 +110,24 @@ export class TransformService {
       }
     }
     let orderDirection = args.orderDir()[0] || 'ASC'
-    if ((args.after && orderDirection === 'ASC') || (args.before && orderDirection === 'DESC')) {
-      where[orderByField] = { $gte: decoded }
+    const cmp =
+      (args.after && orderDirection === 'ASC') || (args.before && orderDirection === 'DESC')
+        ? '$gte'
+        : '$lte'
+    if (isRelevance) {
+      if (args.after || args.before) {
+        let parsed: { order: number | null; id: string }
+        try {
+          parsed = JSON.parse(decoded)
+        } catch (e) {
+          throw new GraphQLError('Invalid cursor')
+        }
+        const cursorOrder = parsed.order ?? 0
+        const rawCmp = cmp === '$gte' ? '>=' : '<='
+        where[raw(`(rank_order, id) ${rawCmp} (?, ?)`, [cursorOrder, parsed.id])] = true
+      }
     } else if (args.after || args.before) {
-      where[orderByField] = { $lte: decoded }
+      where[orderByField] = { [cmp]: decoded }
     }
     if (args.before || args.last) {
       // Need to flip order direction, then reverse the results
@@ -122,9 +137,11 @@ export class TransformService {
     const options: CursorOptions<any> = {
       where,
       options: {
-        orderBy: {
-          [orderByField]: orderDirection,
-        } as QueryOrderMap<any>,
+        orderBy: isRelevance
+          ? ([{ rankOrder: orderDirection }, { id: orderDirection }] as any)
+          : ({
+              [orderByField]: orderDirection,
+            } as QueryOrderMap<any>),
         limit: (args.first || args.last || DEFAULT_PAGE_SIZE) + 2,
       },
     }
@@ -233,7 +250,11 @@ export class TransformService {
     for (const item of cursor.items) {
       const cls = await this.zService.entityToModel(model, item)
       nodes.push(cls)
-      const itemOrderField = (item as any)[options.orderBy()[0] || 'id']
+      const orderByField = options.orderBy()[0] || 'id'
+      const itemOrderField =
+        orderByField === 'relevance'
+          ? JSON.stringify({ order: (item as any).rankOrder ?? 0, id: (item as any).id })
+          : (item as any)[orderByField]
       const cid = Buffer.from(
         _.isString(itemOrderField) ? itemOrderField : itemOrderField.id,
       ).toString('base64')

--- a/apps/api/src/common/z.schema.ts
+++ b/apps/api/src/common/z.schema.ts
@@ -15,9 +15,15 @@ export const ZJSONObject = z.record(z.string(), z.json())
 export const ZTranslatedField = z.record(z.string(), z.string())
 
 export const RankSchema = z.object({
-  quality: z.number().optional(),
+  llm: z.number().optional(),
+  llm_hash: z.string().optional(),
+  order: z.number().optional(),
+  pop: z.number().optional(),
+  qual: z.number().optional(),
 })
 export type Rank = z.infer<typeof RankSchema>
+
+export const RANK_ORDER_SQL = `coalesce((rank ->> 'order')::double precision, 0.0)`
 
 export const HTTPS_OR_ICON: core.$ZodURLParams = {
   protocol: /^https|icon$/,

--- a/apps/api/src/db/migrations/.snapshot-sage.json
+++ b/apps/api/src/db/migrations/.snapshot-sage.json
@@ -351,11 +351,30 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "categories",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "categories_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"categories_rank_order_idx\" on \"categories\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "categories_pkey",
           "columnNames": [
@@ -865,11 +884,30 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "items",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "items_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"items_rank_order_idx\" on \"items\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "items_pkey",
           "columnNames": [
@@ -1346,6 +1384,16 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "orgs",
@@ -1360,6 +1408,15 @@
           "constraint": true,
           "primary": false,
           "unique": true
+        },
+        {
+          "keyName": "orgs_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"orgs_rank_order_idx\" on \"orgs\" (rank_order desc, id desc)"
         },
         {
           "keyName": "orgs_pkey",
@@ -1473,11 +1530,30 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "places",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "places_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"places_rank_order_idx\" on \"places\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "places_location_index",
           "columnNames": [
@@ -1730,6 +1806,16 @@
           "nullable": true,
           "mappedType": "json"
         },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
+        },
         "region_id": {
           "name": "region_id",
           "type": "varchar(255)",
@@ -1744,6 +1830,15 @@
       "name": "programs",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "programs_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"programs_rank_order_idx\" on \"programs\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "programs_pkey",
           "columnNames": [
@@ -2091,11 +2186,30 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "components",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "components_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"components_rank_order_idx\" on \"components\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "components_pkey",
           "columnNames": [
@@ -2342,11 +2456,30 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "tags",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "tags_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"tags_rank_order_idx\" on \"tags\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "tags_type_tag_id_unique",
           "columnNames": [
@@ -2838,6 +2971,16 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "users",
@@ -2862,6 +3005,15 @@
           "constraint": true,
           "primary": false,
           "unique": true
+        },
+        {
+          "keyName": "users_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"users_rank_order_idx\" on \"users\" (rank_order desc, id desc)"
         },
         {
           "keyName": "users_pkey",
@@ -4920,6 +5072,16 @@
           "primary": false,
           "nullable": true,
           "mappedType": "json"
+        },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
         }
       },
       "name": "variants",
@@ -4934,6 +5096,15 @@
           "constraint": false,
           "primary": false,
           "unique": false
+        },
+        {
+          "keyName": "variants_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"variants_rank_order_idx\" on \"variants\" (rank_order desc, id desc)"
         },
         {
           "keyName": "variants_pkey",
@@ -5081,6 +5252,16 @@
           "nullable": true,
           "mappedType": "json"
         },
+        "rank_order": {
+          "name": "rank_order",
+          "type": "double precision",
+          "generated": "coalesce((rank ->> 'order')::double precision, 0.0) stored",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "double"
+        },
         "org_id": {
           "name": "org_id",
           "type": "varchar(255)",
@@ -5115,6 +5296,15 @@
       "name": "processes",
       "schema": "public",
       "indexes": [
+        {
+          "keyName": "processes_rank_order_idx",
+          "columnNames": [],
+          "composite": false,
+          "constraint": false,
+          "primary": false,
+          "unique": false,
+          "expression": "create index \"processes_rank_order_idx\" on \"processes\" (rank_order desc, id desc)"
+        },
         {
           "keyName": "processes_pkey",
           "columnNames": [

--- a/apps/api/src/db/migrations/Migration20260724010635.ts
+++ b/apps/api/src/db/migrations/Migration20260724010635.ts
@@ -1,0 +1,95 @@
+// this file was generated, do not edit unless creating a new migration
+
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20260724010635 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`alter table "categories"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(
+      `create index "categories_rank_order_idx" on "categories" (rank_order desc, id desc);`,
+    )
+
+    this.addSql(`alter table "items"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "items_rank_order_idx" on "items" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "orgs"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "orgs_rank_order_idx" on "orgs" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "places"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "places_rank_order_idx" on "places" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "programs"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "programs_rank_order_idx" on "programs" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "components"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(
+      `create index "components_rank_order_idx" on "components" (rank_order desc, id desc);`,
+    )
+
+    this.addSql(`alter table "tags"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "tags_rank_order_idx" on "tags" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "users"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "users_rank_order_idx" on "users" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "variants"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(`create index "variants_rank_order_idx" on "variants" (rank_order desc, id desc);`)
+
+    this.addSql(`alter table "processes"
+                 add column "rank_order" double precision generated always as (coalesce((rank ->> 'order')::double precision, 0.0)) stored not null;`)
+    this.addSql(
+      `create index "processes_rank_order_idx" on "processes" (rank_order desc, id desc);`,
+    )
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index "categories_rank_order_idx";`)
+    this.addSql(`alter table "categories"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "items_rank_order_idx";`)
+    this.addSql(`alter table "items"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "orgs_rank_order_idx";`)
+    this.addSql(`alter table "orgs"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "places_rank_order_idx";`)
+    this.addSql(`alter table "places"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "programs_rank_order_idx";`)
+    this.addSql(`alter table "programs"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "components_rank_order_idx";`)
+    this.addSql(`alter table "components"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "tags_rank_order_idx";`)
+    this.addSql(`alter table "tags"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "users_rank_order_idx";`)
+    this.addSql(`alter table "users"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "variants_rank_order_idx";`)
+    this.addSql(`alter table "variants"
+                 drop column "rank_order";`)
+
+    this.addSql(`drop index "processes_rank_order_idx";`)
+    this.addSql(`alter table "processes"
+                 drop column "rank_order";`)
+  }
+}

--- a/apps/api/src/geo/place.entity.ts
+++ b/apps/api/src/geo/place.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -13,7 +14,7 @@ import {
 import type { Ref } from '@mikro-orm/core'
 
 import type { TranslatedField } from '@src/common/i18n'
-import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { CreatedUpdated } from '@src/db/base.entity'
 import { Point, PointType } from '@src/db/custom.types'
 import { Process } from '@src/process/process.entity'
@@ -23,7 +24,13 @@ import { User } from '@src/users/users.entity'
 
 @Entity({ tableName: 'places', schema: 'public' })
 @Index({ properties: ['location'], type: 'gist' })
+@Index({
+  name: 'places_rank_order_idx',
+  expression: `create index "places_rank_order_idx" on "places" (rank_order desc, id desc)`,
+})
 export class Place extends CreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @PrimaryKey()
   id!: string
 
@@ -47,6 +54,9 @@ export class Place extends CreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => Tag, pivotEntity: () => PlacesTag })
   tags = new Collection<Tag>(this)

--- a/apps/api/src/geo/place.model.ts
+++ b/apps/api/src/geo/place.model.ts
@@ -11,7 +11,7 @@ import { IsNanoID } from '@src/common/validator.model'
 import { type JSONObject } from '@src/common/z.schema'
 import { CreatedUpdated, registerModel, TranslatedInput } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { TagConnection } from '@src/process/tag.model'
 import { Org } from '@src/users/org.model'
 
@@ -120,6 +120,14 @@ export class PlacesArgs extends PaginationBasicArgs {
 
   @Field(() => String, { nullable: true })
   query?: string
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @InputType()

--- a/apps/api/src/process/component.entity.ts
+++ b/apps/api/src/process/component.entity.ts
@@ -2,9 +2,11 @@ import {
   BaseEntity,
   Collection,
   Entity,
+  Index,
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -14,7 +16,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import type { TranslatedField } from '@src/common/i18n'
-import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Material } from '@src/process/material.entity'
@@ -62,7 +64,13 @@ export const ComponentPhysicalSchema = z.object({
 export type ComponentPhysical = z.infer<typeof ComponentPhysicalSchema>
 
 @Entity({ tableName: 'components', schema: 'public' })
+@Index({
+  name: 'components_rank_order_idx',
+  expression: `create index "components_rank_order_idx" on "components" (rank_order desc, id desc)`,
+})
 export class Component extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -99,6 +107,9 @@ export class Component extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({
     entity: () => Material,

--- a/apps/api/src/process/component.model.ts
+++ b/apps/api/src/process/component.model.ts
@@ -18,7 +18,7 @@ import {
   TranslatedInput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { type ComponentPhysical, type ComponentVisual } from '@src/process/component.entity'
 import { Material } from '@src/process/material.model'
 import {
@@ -198,6 +198,14 @@ export class ComponentsArgs extends PaginationBasicArgs {
 
   @Field(() => String, { nullable: true })
   query?: string
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/process/process.entity.ts
+++ b/apps/api/src/process/process.entity.ts
@@ -2,9 +2,11 @@ import {
   BaseEntity,
   Collection,
   Entity,
+  Index,
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -14,7 +16,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import type { TranslatedField } from '@src/common/i18n'
-import type { Rank } from '@src/common/z.schema'
+import { type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Region } from '@src/geo/region.entity'
@@ -199,7 +201,13 @@ export const ProcessEfficiencySchema = z.object({
 })
 
 @Entity({ tableName: 'processes', schema: 'public' })
+@Index({
+  name: 'processes_rank_order_idx',
+  expression: `create index "processes_rank_order_idx" on "processes" (rank_order desc, id desc)`,
+})
 export class Process extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'text' })
   intent!: ProcessIntent
 
@@ -236,6 +244,9 @@ export class Process extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => Source, pivotEntity: () => ProcessSources })
   sources = new Collection<Source>(this)

--- a/apps/api/src/process/process.model.ts
+++ b/apps/api/src/process/process.model.ts
@@ -19,7 +19,7 @@ import {
   TranslatedInput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { Material } from '@src/process/material.model'
 import { ProcessIntent } from '@src/process/process.entity'
 import { Variant } from '@src/product/variant.model'
@@ -169,6 +169,14 @@ export class ProcessArgs extends PaginationBasicArgs {
 
   @Field(() => ID, { nullable: true })
   material?: string
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @InputType()

--- a/apps/api/src/process/program.entity.ts
+++ b/apps/api/src/process/program.entity.ts
@@ -3,9 +3,11 @@ import {
   Collection,
   Entity,
   Enum,
+  Index,
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -13,7 +15,7 @@ import {
 import type { Ref } from '@mikro-orm/core'
 
 import type { TranslatedField } from '@src/common/i18n'
-import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Process } from '@src/process/process.entity'
@@ -28,7 +30,13 @@ export enum ProgramStatus {
 }
 
 @Entity({ tableName: 'programs', schema: 'public' })
+@Index({
+  name: 'programs_rank_order_idx',
+  expression: `create index "programs_rank_order_idx" on "programs" (rank_order desc, id desc)`,
+})
 export class Program extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -46,6 +54,9 @@ export class Program extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToOne()
   region?: Ref<Region>

--- a/apps/api/src/process/program.model.ts
+++ b/apps/api/src/process/program.model.ts
@@ -15,7 +15,7 @@ import {
   TranslatedInput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { ProcessConnection } from '@src/process/process.model'
 import { ProgramStatus } from '@src/process/program.entity'
 import { TagConnection } from '@src/process/tag.model'
@@ -94,6 +94,14 @@ export class ProgramHistoryArgs extends PaginationBasicArgs {
 @ArgsType()
 export class ProgramsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/process/tag.entity.ts
+++ b/apps/api/src/process/tag.entity.ts
@@ -1,9 +1,24 @@
-import { Collection, Entity, Enum, ManyToMany, Property, Unique } from '@mikro-orm/core'
+import {
+  Collection,
+  Entity,
+  Enum,
+  Index,
+  ManyToMany,
+  OptionalProps,
+  Property,
+  Unique,
+} from '@mikro-orm/core'
 import { JSONSchemaType } from 'ajv/dist/2020'
 import { z } from 'zod/v4'
 
 import { type TranslatedField } from '@src/common/i18n'
-import { AjvTemplateSchema, JSONType, type Rank, ZTranslatedField } from '@src/common/z.schema'
+import {
+  AjvTemplateSchema,
+  JSONType,
+  type Rank,
+  RANK_ORDER_SQL,
+  ZTranslatedField,
+} from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Place } from '@src/geo/place.entity'
 import { Component } from '@src/process/component.entity'
@@ -70,7 +85,13 @@ export type TagRules = z.infer<typeof TagRulesSchema>
 
 @Entity({ tableName: 'tags', schema: 'public' })
 @Unique({ properties: ['type', 'tag_id'] })
+@Index({
+  name: 'tags_rank_order_idx',
+  expression: `create index "tags_rank_order_idx" on "tags" (rank_order desc, id desc)`,
+})
 export class Tag extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -97,6 +118,9 @@ export class Tag extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => Place, mappedBy: 'tags' })
   places = new Collection<Place>(this)

--- a/apps/api/src/process/tag.model.ts
+++ b/apps/api/src/process/tag.model.ts
@@ -5,7 +5,7 @@ import { z } from 'zod/v4'
 import { type JSONObject, type JSONType } from '@src/common/z.schema'
 import { IDCreatedUpdated, registerModel } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { TagType } from '@src/process/tag.entity'
 
 registerEnumType(TagType, {
@@ -70,6 +70,14 @@ export class TagConnection extends Paginated(Tag) {}
 @ArgsType()
 export class TagArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 export const TagDefinitionIDSchema = z.string().meta({

--- a/apps/api/src/product/category.entity.ts
+++ b/apps/api/src/product/category.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -13,7 +14,7 @@ import {
 import type { Ref } from '@mikro-orm/core'
 
 import type { TranslatedField } from '@src/common/i18n'
-import type { Rank } from '@src/common/z.schema'
+import { type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Item } from '@src/product/item.entity'
 import { User } from '@src/users/users.entity'
@@ -21,7 +22,13 @@ import { User } from '@src/users/users.entity'
 export const CATEGORY_ROOT = 'CATEGORY_ROOT'
 
 @Entity({ tableName: 'categories', schema: 'public' })
+@Index({
+  name: 'categories_rank_order_idx',
+  expression: `create index "categories_rank_order_idx" on "categories" (rank_order desc, id desc)`,
+})
 export class Category extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -36,6 +43,9 @@ export class Category extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @OneToMany({ entity: () => CategoryTree, mappedBy: 'ancestor' })
   ancestors = new Collection<CategoryTree>(this)

--- a/apps/api/src/product/category.model.ts
+++ b/apps/api/src/product/category.model.ts
@@ -14,7 +14,7 @@ import {
   TranslatedOutput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { ItemsConnection } from '@src/product/item.model'
 import { User as UserEntity } from '@src/users/users.entity'
 import { User } from '@src/users/users.model'
@@ -122,6 +122,14 @@ export class CategoryHistoryArgs extends PaginationBasicArgs {
 @ArgsType()
 export class CategoriesArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/product/item.entity.ts
+++ b/apps/api/src/product/item.entity.ts
@@ -2,9 +2,11 @@ import {
   BaseEntity,
   Collection,
   Entity,
+  Index,
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -13,7 +15,7 @@ import {
 import { z } from 'zod/v4'
 
 import { type TranslatedField } from '@src/common/i18n'
-import type { Rank } from '@src/common/z.schema'
+import { type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Tag } from '@src/process/tag.entity'
 import { Category } from '@src/product/category.entity'
@@ -34,7 +36,13 @@ export const ItemFilesSchema = z.object({
 export type ItemFiles = z.infer<typeof ItemFilesSchema>
 
 @Entity({ tableName: 'items', schema: 'public' })
+@Index({
+  name: 'items_rank_order_idx',
+  expression: `create index "items_rank_order_idx" on "items" (rank_order desc, id desc)`,
+})
 export class Item extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -52,6 +60,9 @@ export class Item extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => Category, pivotEntity: () => ItemsCategories })
   categories = new Collection<Category>(this)

--- a/apps/api/src/product/item.model.ts
+++ b/apps/api/src/product/item.model.ts
@@ -16,7 +16,7 @@ import {
   TranslatedInput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { ComponentsConnection } from '@src/process/component.model'
 import {
   RecyclingStream,
@@ -192,6 +192,14 @@ export class ItemHistoryArgs extends PaginationBasicArgs {
 @ArgsType()
 export class ItemsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/product/variant.entity.ts
+++ b/apps/api/src/product/variant.entity.ts
@@ -2,10 +2,12 @@ import {
   BaseEntity,
   Collection,
   Entity,
+  Index,
   ManyToMany,
   ManyToOne,
   OneToMany,
   type Opt,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -15,7 +17,7 @@ import { z } from 'zod/v4'
 
 import { Source } from '@src/changes/source.entity'
 import { type TranslatedField } from '@src/common/i18n'
-import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Component } from '@src/process/component.entity'
@@ -36,7 +38,13 @@ export const VariantOrgRoleSchema = z.enum(['PRODUCER', 'DISTRIBUTOR']).optional
 export type VariantOrgRole = z.infer<typeof VariantOrgRoleSchema>
 
 @Entity({ tableName: 'variants', schema: 'public' })
+@Index({
+  name: 'variants_rank_order_idx',
+  expression: `create index "variants_rank_order_idx" on "variants" (rank_order desc, id desc)`,
+})
 export class Variant extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ type: 'json' })
   name!: TranslatedField
 
@@ -66,6 +74,9 @@ export class Variant extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => Org, pivotEntity: () => VariantsOrgs })
   orgs = new Collection<Org>(this)

--- a/apps/api/src/product/variant.model.ts
+++ b/apps/api/src/product/variant.model.ts
@@ -19,7 +19,7 @@ import {
   TranslatedInput,
 } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { Component, ComponentsConnection } from '@src/process/component.model'
 import {
   RecyclingStream,
@@ -267,6 +267,14 @@ export class VariantRegionsArgs extends PaginationBasicArgs {
 @ArgsType()
 export class VariantsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/users/org.entity.ts
+++ b/apps/api/src/users/org.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -13,7 +14,7 @@ import {
 } from '@mikro-orm/core'
 
 import { defaultTranslatedField, type TranslatedField } from '@src/common/i18n'
-import { type JSONObject, type Rank } from '@src/common/z.schema'
+import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Process } from '@src/process/process.entity'
 import { Program } from '@src/process/program.entity'
@@ -21,7 +22,13 @@ import { Variant } from '@src/product/variant.entity'
 import { User } from '@src/users/users.entity'
 
 @Entity({ tableName: 'orgs', schema: 'public' })
+@Index({
+  name: 'orgs_rank_order_idx',
+  expression: `create index "orgs_rank_order_idx" on "orgs" (rank_order desc, id desc)`,
+})
 export class Org extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   @Property({ length: 128 })
   name!: string
 
@@ -45,6 +52,9 @@ export class Org extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @ManyToMany({ entity: () => User, mappedBy: 'orgs' })
   users = new Collection<User>(this)

--- a/apps/api/src/users/org.model.ts
+++ b/apps/api/src/users/org.model.ts
@@ -8,7 +8,7 @@ import { LuxonDateTimeResolver } from '@src/common/datetime.model'
 import { IsNanoID } from '@src/common/validator.model'
 import { BaseModel, IDCreatedUpdated, type ModelRef, registerModel } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
-import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { User as UserEntity } from '@src/users/users.entity'
 import { User, UserConnection } from '@src/users/users.model'
 
@@ -72,6 +72,14 @@ export class OrgsConnection extends Paginated(Org) {}
 @ArgsType()
 export class OrgsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
+
+  orderBy(): string[] {
+    return ['relevance']
+  }
+
+  orderDir(): OrderDirection[] {
+    return [OrderDirection.DESC]
+  }
 }
 
 @ArgsType()

--- a/apps/api/src/users/users.entity.ts
+++ b/apps/api/src/users/users.entity.ts
@@ -5,13 +5,14 @@ import {
   ManyToMany,
   ManyToOne,
   OneToMany,
+  OptionalProps,
   Property,
 } from '@mikro-orm/core'
 import type { Opt } from '@mikro-orm/core'
 
 import { Account } from '@src/auth/account.entity'
 import { Session } from '@src/auth/session.entity'
-import type { Rank } from '@src/common/z.schema'
+import { type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Org } from '@src/users/org.entity'
 
@@ -20,7 +21,13 @@ export interface ProfileField {
 }
 
 @Entity({ tableName: 'users', schema: 'public' })
+@Index({
+  name: 'users_rank_order_idx',
+  expression: `create index "users_rank_order_idx" on "users" (rank_order desc, id desc)`,
+})
 export class User extends IDCreatedUpdated {
+  [OptionalProps]?: 'rankOrder'
+
   constructor(email: string, username: string, name: string) {
     super()
     this.email = email
@@ -66,6 +73,9 @@ export class User extends IDCreatedUpdated {
 
   @Property({ type: 'json' })
   rank?: Rank
+
+  @Property({ type: 'double precision', generated: `(${RANK_ORDER_SQL}) stored`, nullable: false })
+  rankOrder!: number
 
   @OneToMany({ mappedBy: 'user' })
   sessions = new Collection<Session>(this)


### PR DESCRIPTION
Closes #117 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default all list endpoints to sort by relevance and make pagination stable and fast by indexing a generated `rank_order` column. Cursors now use `(rank_order, id)` when ordering by relevance.

- **New Features**
  - Default ordering to relevance (DESC) for lists across categories, items, variants, components, processes, programs, places, orgs, users, and tags.
  - Stable cursor pagination for relevance: cursors encode `{ order, id }` and use `(rank_order, id)` comparison.
  - Expanded `Rank` schema with `llm`, `llm_hash`, `order`, `pop`, `qual`.

- **Migration**
  - Add generated `rank_order` column and composite indexes `(rank_order desc, id desc)` to all affected tables.
  - Run DB migration; no data backfill needed (column is computed).

<sup>Written for commit 4ffd7ce56eb88f11f4472eae601b86a9f7153245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

