### PR TITLE
api: Define an MCP server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -45,6 +45,7 @@
     "@mikro-orm/seeder": "^6.6.6",
     "@mikro-orm/sql-highlighter": "^1.0.1",
     "@mistralai/mistralai": "^2.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@nestjs/apollo": "^13.2.4",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.1.17",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -20,6 +20,7 @@ import { FeedbackModule } from '@src/feedback/feedback.module'
 import { GeoModule } from '@src/geo/geo.module'
 import { GraphQLModule } from '@src/graphql/graphql.module'
 import { HealthModule } from '@src/health/health.module'
+import { McpModule } from '@src/mcp/mcp.module'
 import { MIKRO_CONFIG } from '@src/mikro-orm.config'
 import { ProcessModule } from '@src/process/process.module'
 import { ProductModule } from '@src/product/product.module'
@@ -79,6 +80,7 @@ if (dotenv) {
     FeedModule,
     FeedbackModule,
     WindmillModule,
+    McpModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }, AppService],
 })

--- a/apps/api/src/mcp/mcp-rate-limit.guard.ts
+++ b/apps/api/src/mcp/mcp-rate-limit.guard.ts
@@ -1,0 +1,41 @@
+import { CanActivate, ExecutionContext, HttpException, Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Response } from 'express'
+
+import { AuthUserService } from '@src/auth/authuser.service'
+import { RateLimitService } from '@src/rate-limit/rate-limit.service'
+
+@Injectable()
+export class McpRateLimitGuard implements CanActivate {
+  constructor(
+    private readonly rateLimitService: RateLimitService,
+    private readonly authUser: AuthUserService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const httpContext = context.switchToHttp()
+    const request = httpContext.getRequest()
+
+    // GET/DELETE are rejected with 405 by the controller itself; only throttle writes/reads via POST.
+    if (request.method !== 'POST') return true
+
+    if (this.configService.get('rateLimit.enabled') === false) return true
+
+    const userID = this.authUser.userID()
+    if (!userID) return true // AuthGuard (global) already rejects unauthenticated requests
+
+    const { allowed, retryAfterMs } = await this.rateLimitService.consume(
+      userID,
+      1,
+      'authenticated',
+    )
+    if (!allowed) {
+      const response = httpContext.getResponse<Response>()
+      response.setHeader('Retry-After', String(Math.ceil(retryAfterMs / 1000)))
+      throw new HttpException('Rate limit exceeded', 429)
+    }
+
+    return true
+  }
+}

--- a/apps/api/src/mcp/mcp-tools.registry.ts
+++ b/apps/api/src/mcp/mcp-tools.registry.ts
@@ -1,0 +1,27 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+import { McpToolContext } from '@src/mcp/mcp.types'
+import { registerBeginChangeTool } from '@src/mcp/tools/begin-change.tool'
+import { registerEditChangeTool } from '@src/mcp/tools/edit-change.tool'
+import { registerGraphqlIntrospectionTool } from '@src/mcp/tools/graphql-introspection.tool'
+import { registerGraphqlQueryTool } from '@src/mcp/tools/graphql-query.tool'
+import { registerProposeEditTool } from '@src/mcp/tools/propose-edit.tool'
+import { registerProposeRefsTool } from '@src/mcp/tools/propose-refs.tool'
+import { registerSearchCatalogTool } from '@src/mcp/tools/search-catalog.tool'
+import { registerWhoamiTool } from '@src/mcp/tools/whoami.tool'
+
+export function buildMcpServer(ctx: McpToolContext): McpServer {
+  const server = new McpServer({ name: 'sage-api', version: '1.0.0' })
+
+  registerWhoamiTool(server, ctx)
+  registerSearchCatalogTool(server, ctx)
+  registerGraphqlQueryTool(server, ctx)
+  registerGraphqlIntrospectionTool(server, ctx)
+
+  registerBeginChangeTool(server, ctx)
+  registerEditChangeTool(server, ctx)
+  registerProposeEditTool(server, ctx)
+  registerProposeRefsTool(server, ctx)
+
+  return server
+}

--- a/apps/api/src/mcp/mcp.controller.spec.ts
+++ b/apps/api/src/mcp/mcp.controller.spec.ts
@@ -1,0 +1,347 @@
+import { MikroORM } from '@mikro-orm/postgresql'
+import { INestApplication } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { AppTestModule } from '@test/app-test.module'
+import { GraphQLTestClient } from '@test/graphql.utils'
+import request from 'supertest'
+
+import { BaseSeeder } from '@src/db/seeds/BaseSeeder'
+import { UserSeeder } from '@src/db/seeds/UserSeeder'
+import { clearDatabase } from '@src/db/test.utils'
+import { SearchService } from '@src/search/search.service'
+import { User } from '@src/users/users.entity'
+import { WindmillMockService } from '@src/windmill/windmill.mock.service'
+import { WindmillService } from '@src/windmill/windmill.service'
+
+const MCP_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+  'Accept-Language': 'en',
+}
+
+// The transport streams SSE by default (no `enableJsonResponse`), so responses arrive as
+// `data: {...}` lines rather than a plain JSON body - parse out the JSON-RPC payload.
+function parseSSE(body: string): any[] {
+  return body
+    .split('\n\n')
+    .map((chunk) => chunk.split('\n').find((line) => line.startsWith('data: ')))
+    .filter((line): line is string => Boolean(line))
+    .map((line) => JSON.parse(line.slice('data: '.length)))
+}
+
+describe('MCP Server (integration)', () => {
+  let app: INestApplication
+  let orm: MikroORM
+  let adminUser: User
+  let authCookie: string
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppTestModule],
+    })
+      .overrideProvider(SearchService)
+      .useValue({
+        searchAll: async () => null,
+      })
+      .overrideProvider(WindmillService)
+      .useClass(WindmillMockService)
+      .compile()
+
+    app = module.createNestApplication()
+    await app.init()
+
+    orm = module.get<MikroORM>(MikroORM)
+
+    await clearDatabase(orm, 'auth')
+    await clearDatabase(orm, 'public')
+    await orm.seeder.seed(BaseSeeder, UserSeeder)
+
+    adminUser = await orm.em.findOneOrFail(User, { username: 'admin' })
+
+    const cookieGql = new GraphQLTestClient(app)
+    await cookieGql.signIn('admin', 'password')
+    const cookies: string[] = (cookieGql as any).cookies
+    authCookie = cookies.map((c) => c.split(';')[0]).join('; ')
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  function mcpRequest(body: object) {
+    return request(app.getHttpServer())
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .set('Cookie', authCookie)
+      .send(body)
+  }
+
+  test('request without auth is rejected with 401', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 })
+
+    expect(res.status).toBe(401)
+  })
+
+  test('GET /mcp is rejected with 405', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/mcp')
+      .set('Cookie', authCookie)
+      .set('Accept', 'application/json, text/event-stream')
+
+    expect(res.status).toBe(405)
+  })
+
+  test('DELETE /mcp is rejected with 405', async () => {
+    const res = await request(app.getHttpServer())
+      .delete('/mcp')
+      .set('Cookie', authCookie)
+      .set('Accept', 'application/json, text/event-stream')
+
+    expect(res.status).toBe(405)
+  })
+
+  test('initialize succeeds as an independent stateless request', async () => {
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+      id: 1,
+    })
+
+    expect(res.status).toBe(200)
+    const [event] = parseSSE(res.text)
+    expect(event.result.serverInfo.name).toBe('sage-api')
+  })
+
+  test('tools/list succeeds as an independent stateless request (no prior initialize needed)', async () => {
+    const res = await mcpRequest({ jsonrpc: '2.0', method: 'tools/list', id: 1 })
+
+    expect(res.status).toBe(200)
+    const [event] = parseSSE(res.text)
+    const names = event.result.tools.map((t: any) => t.name)
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'whoami',
+        'search_catalog',
+        'graphql_query',
+        'graphql_introspection',
+        'begin_change',
+        'edit_change',
+        'propose_edit',
+        'propose_refs',
+      ]),
+    )
+  })
+
+  test('graphql_introspection returns the schema SDL, or a single type on request', async () => {
+    const fullRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'graphql_introspection', arguments: {} },
+      id: 1,
+    })
+    const fullEvent = parseSSE(fullRes.text)[0]
+    expect(fullEvent.result.isError).toBeFalsy()
+    expect(fullEvent.result.content[0].text).toContain('type Query')
+
+    const typeRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'graphql_introspection', arguments: { typeName: 'Item' } },
+      id: 1,
+    })
+    const typeEvent = parseSSE(typeRes.text)[0]
+    expect(typeEvent.result.isError).toBeFalsy()
+    expect(typeEvent.result.content[0].text).toContain('type Item')
+
+    const missingRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'graphql_introspection', arguments: { typeName: 'NotARealType' } },
+      id: 1,
+    })
+    const missingEvent = parseSSE(missingRes.text)[0]
+    expect(missingEvent.result.isError).toBe(true)
+  })
+
+  test('graphql_query runs a read query as the authenticated user', async () => {
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'graphql_query', arguments: { query: '{ me { id username } }' } },
+      id: 1,
+    })
+
+    expect(res.status).toBe(200)
+    const event = parseSSE(res.text)[0]
+    expect(event.result.isError).toBeFalsy()
+    const payload = JSON.parse(event.result.content[0].text)
+    expect(payload.data.me.id).toBe(adminUser.id)
+    expect(payload.data.me.username).toBe('admin')
+  })
+
+  test('graphql_query rejects mutations', async () => {
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'graphql_query',
+        arguments: {
+          query:
+            'mutation { createChange(input: { title: "should be rejected" }) { change { id } } }',
+        },
+      },
+      id: 1,
+    })
+
+    const event = parseSSE(res.text)[0]
+    expect(event.result.isError).toBe(true)
+    expect(event.result.content[0].text).toMatch(/only "query" operations/i)
+  })
+
+  test('tools/call whoami returns the authenticated user', async () => {
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'whoami', arguments: {} },
+      id: 1,
+    })
+
+    expect(res.status).toBe(200)
+    const [event] = parseSSE(res.text)
+    const payload = JSON.parse(event.result.content[0].text)
+    expect(payload.id).toBe(adminUser.id)
+  })
+
+  test('search_catalog returns structured content that satisfies its output schema', async () => {
+    const res = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'search_catalog',
+        arguments: { query: 'mcp-integration-test-no-results-expected' },
+      },
+      id: 1,
+    })
+
+    expect(res.status).toBe(200)
+    const [event] = parseSSE(res.text)
+    expect(event.result.isError).toBeFalsy()
+    expect(event.result.structuredContent).toEqual({
+      items: [],
+      totalCount: 0,
+      facets: [],
+    })
+    expect(JSON.parse(event.result.content[0].text)).toEqual(event.result.structuredContent)
+  })
+
+  test('begin_change -> propose_edit -> propose_refs round trip, then status lock', async () => {
+    const beginRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'begin_change', arguments: { title: 'MCP integration test change' } },
+      id: 1,
+    })
+    const beginPayload = JSON.parse(parseSSE(beginRes.text)[0].result.content[0].text)
+    const changeID = beginPayload.changeID
+    expect(changeID).toBeDefined()
+    expect(beginPayload.status).toBe('DRAFT')
+
+    const proposeRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'propose_edit',
+        arguments: {
+          model: 'Item',
+          mode: 'create',
+          changeID,
+          data: { name: 'MCP Test Item' },
+        },
+      },
+      id: 1,
+    })
+    const proposeEvent = parseSSE(proposeRes.text)[0]
+    expect(proposeEvent.result.isError).toBeFalsy()
+    const proposePayload = JSON.parse(proposeEvent.result.content[0].text)
+    expect(proposePayload.entity.name).toBe('MCP Test Item')
+    const itemID = proposePayload.entity.id
+
+    const refsRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'propose_refs',
+        arguments: {
+          model: 'Item',
+          id: itemID,
+          changeID,
+          refs: [{ refModel: 'Category', refField: 'categories', refs: [] }],
+        },
+      },
+      id: 1,
+    })
+    expect(refsRes.status).toBe(200)
+
+    // Move the change to PROPOSED - further propose_edit/propose_refs calls should be locked out
+    const editChangeRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'edit_change', arguments: { changeID, status: 'PROPOSED' } },
+      id: 1,
+    })
+    const editChangePayload = JSON.parse(parseSSE(editChangeRes.text)[0].result.content[0].text)
+    expect(editChangePayload.status).toBe('PROPOSED')
+
+    const lockedRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'propose_edit',
+        arguments: {
+          model: 'Item',
+          mode: 'update',
+          changeID,
+          data: { id: itemID, name: 'Should be rejected' },
+        },
+      },
+      id: 1,
+    })
+    const lockedEvent = parseSSE(lockedRes.text)[0]
+    expect(lockedEvent.result.isError).toBe(true)
+
+    // Move back to DRAFT - edits should succeed again
+    await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: { name: 'edit_change', arguments: { changeID, status: 'DRAFT' } },
+      id: 1,
+    })
+
+    const reopenedRes = await mcpRequest({
+      jsonrpc: '2.0',
+      method: 'tools/call',
+      params: {
+        name: 'propose_edit',
+        arguments: {
+          model: 'Item',
+          mode: 'update',
+          changeID,
+          data: { id: itemID, name: 'MCP Test Item Updated' },
+        },
+      },
+      id: 1,
+    })
+    const reopenedEvent = parseSSE(reopenedRes.text)[0]
+    expect(reopenedEvent.result.isError).toBeFalsy()
+    const reopenedPayload = JSON.parse(reopenedEvent.result.content[0].text)
+    expect(reopenedPayload.entity.name).toBe('MCP Test Item Updated')
+  })
+})

--- a/apps/api/src/mcp/mcp.controller.ts
+++ b/apps/api/src/mcp/mcp.controller.ts
@@ -1,0 +1,168 @@
+import type { ApolloServer, BaseContext } from '@apollo/server'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { ApolloDriver } from '@nestjs/apollo'
+import { Controller, Delete, Get, OnModuleInit, Post, Req, Res, UseGuards } from '@nestjs/common'
+import { ModuleRef } from '@nestjs/core'
+import { AbstractGraphQLDriver, GraphQLSchemaHost } from '@nestjs/graphql'
+import type { Request, Response } from 'express'
+import type { GraphQLSchema } from 'graphql'
+
+import { AuthUser } from '@src/auth/auth.guard'
+import type { ReqUser } from '@src/auth/auth.guard'
+import { ChangeSchemaService } from '@src/changes/change.schema'
+import { ChangeService } from '@src/changes/change.service'
+import { RefEditService } from '@src/changes/ref-edit.service'
+import { TransformService } from '@src/common/transform'
+import { PlaceSchemaService } from '@src/geo/place.schema'
+import { PlaceService } from '@src/geo/place.service'
+import { McpRateLimitGuard } from '@src/mcp/mcp-rate-limit.guard'
+import { buildMcpServer } from '@src/mcp/mcp-tools.registry'
+import { McpToolContext } from '@src/mcp/mcp.types'
+import { ComponentSchemaService } from '@src/process/component.schema'
+import { ComponentService } from '@src/process/component.service'
+import { ProcessSchemaService } from '@src/process/process.schema'
+import { ProcessService } from '@src/process/process.service'
+import { ProgramSchemaService } from '@src/process/program.schema'
+import { ProgramService } from '@src/process/program.service'
+import { CategorySchemaService } from '@src/product/category.schema'
+import { CategoryService } from '@src/product/category.service'
+import { ItemSchemaService } from '@src/product/item.schema'
+import { ItemService } from '@src/product/item.service'
+import { VariantSchemaService } from '@src/product/variant.schema'
+import { VariantService } from '@src/product/variant.service'
+import { SearchService } from '@src/search/search.service'
+import { OrgSchemaService } from '@src/users/org.schema'
+import { OrgService } from '@src/users/org.service'
+
+const JSON_RPC_METHOD_NOT_ALLOWED = {
+  jsonrpc: '2.0',
+  error: { code: -32000, message: 'Method not allowed.' },
+  id: null,
+}
+
+@Controller('mcp')
+@UseGuards(McpRateLimitGuard)
+export class McpController implements OnModuleInit {
+  /**
+   * Resolved once in onModuleInit via ModuleRef's non-strict lookup - neither AbstractGraphQLDriver
+   * nor GraphQLSchemaHost is exported by @nestjs/graphql's own module, and McpModule doesn't import
+   * it (importing GraphQLModule.register() a second time would build a second ApolloDriver/schema
+   * and crash schema generation), so normal constructor DI can't reach them. ModuleRef.get(_, {
+   * strict: false }) is Nest's documented escape hatch for reaching another module's internal
+   * provider regardless of what the current module imports.
+   *
+   * apolloServer matters specifically because graphql_query calls apolloServer.executeOperation()
+   * rather than calling graphql-js's execute() directly against the schema - that runs the query
+   * through the exact same plugin pipeline a real /graphql request does (RateLimitPlugin's
+   * complexity-based rate limiting, ApolloServerPluginResponseCache, formatError), instead of
+   * silently skipping all of that.
+   */
+  private apolloServer!: ApolloServer<BaseContext>
+  private schema!: GraphQLSchema
+
+  constructor(
+    private readonly moduleRef: ModuleRef,
+    private readonly transform: TransformService,
+    private readonly changeService: ChangeService,
+    private readonly changeSchemaService: ChangeSchemaService,
+    private readonly refEditService: RefEditService,
+    private readonly searchService: SearchService,
+    private readonly itemService: ItemService,
+    private readonly itemSchemaService: ItemSchemaService,
+    private readonly processService: ProcessService,
+    private readonly processSchemaService: ProcessSchemaService,
+    private readonly variantService: VariantService,
+    private readonly variantSchemaService: VariantSchemaService,
+    private readonly categoryService: CategoryService,
+    private readonly categorySchemaService: CategorySchemaService,
+    private readonly placeService: PlaceService,
+    private readonly placeSchemaService: PlaceSchemaService,
+    private readonly orgService: OrgService,
+    private readonly orgSchemaService: OrgSchemaService,
+    private readonly componentService: ComponentService,
+    private readonly componentSchemaService: ComponentSchemaService,
+    private readonly programService: ProgramService,
+    private readonly programSchemaService: ProgramSchemaService,
+  ) {}
+
+  onModuleInit() {
+    const driver = this.moduleRef.get(AbstractGraphQLDriver, { strict: false }) as ApolloDriver
+    this.apolloServer = driver.instance
+    this.schema = this.moduleRef.get(GraphQLSchemaHost, { strict: false }).schema
+  }
+
+  @Post()
+  async handlePost(@Req() req: Request, @Res() res: Response, @AuthUser() user: ReqUser | null) {
+    if (!user) {
+      res.status(401).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Unauthorized' },
+        id: null,
+      })
+      return
+    }
+
+    const ctx: McpToolContext = {
+      userID: user.id,
+      reqUser: user,
+      rawReq: req,
+      schema: this.schema,
+      apolloServer: this.apolloServer,
+      transform: this.transform,
+      changeService: this.changeService,
+      changeSchemaService: this.changeSchemaService,
+      refEditService: this.refEditService,
+      searchService: this.searchService,
+      itemService: this.itemService,
+      itemSchemaService: this.itemSchemaService,
+      processService: this.processService,
+      processSchemaService: this.processSchemaService,
+      variantService: this.variantService,
+      variantSchemaService: this.variantSchemaService,
+      categoryService: this.categoryService,
+      categorySchemaService: this.categorySchemaService,
+      placeService: this.placeService,
+      placeSchemaService: this.placeSchemaService,
+      orgService: this.orgService,
+      orgSchemaService: this.orgSchemaService,
+      componentService: this.componentService,
+      componentSchemaService: this.componentSchemaService,
+      programService: this.programService,
+      programSchemaService: this.programSchemaService,
+    }
+
+    const server = buildMcpServer(ctx)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined })
+    res.on('close', () => {
+      transport.close()
+      server.close()
+    })
+
+    try {
+      await server.connect(transport)
+      await transport.handleRequest(req, res, req.body)
+    } catch {
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        })
+      }
+    }
+  }
+
+  @Get()
+  handleGet(@Res() res: Response) {
+    res
+      .writeHead(405, { 'Content-Type': 'application/json' })
+      .end(JSON.stringify(JSON_RPC_METHOD_NOT_ALLOWED))
+  }
+
+  @Delete()
+  handleDelete(@Res() res: Response) {
+    res
+      .writeHead(405, { 'Content-Type': 'application/json' })
+      .end(JSON.stringify(JSON_RPC_METHOD_NOT_ALLOWED))
+  }
+}

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common'
+
+import { AuthModule } from '@src/auth/auth.module'
+import { ChangesModule } from '@src/changes/changes.module'
+import { GeoModule } from '@src/geo/geo.module'
+import { McpRateLimitGuard } from '@src/mcp/mcp-rate-limit.guard'
+import { McpController } from '@src/mcp/mcp.controller'
+import { ProcessModule } from '@src/process/process.module'
+import { ProductModule } from '@src/product/product.module'
+import { RateLimitModule } from '@src/rate-limit/rate-limit.module'
+import { SearchModule } from '@src/search/search.module'
+import { UsersModule } from '@src/users/users.module'
+
+@Module({
+  imports: [
+    AuthModule,
+    SearchModule,
+    ProductModule,
+    ProcessModule,
+    GeoModule,
+    ChangesModule,
+    RateLimitModule,
+    UsersModule,
+  ],
+  controllers: [McpController],
+  providers: [McpRateLimitGuard],
+})
+export class McpModule {}

--- a/apps/api/src/mcp/mcp.types.ts
+++ b/apps/api/src/mcp/mcp.types.ts
@@ -1,0 +1,105 @@
+import type { ApolloServer, BaseContext } from '@apollo/server'
+import type { Request } from 'express'
+import type { GraphQLSchema } from 'graphql'
+
+import { ReqUser } from '@src/auth/auth.guard'
+import { ChangeStatus } from '@src/changes/change.entity'
+import { ChangeSchemaService } from '@src/changes/change.schema'
+import { ChangeService } from '@src/changes/change.service'
+import { RefEditService } from '@src/changes/ref-edit.service'
+import { TransformService } from '@src/common/transform'
+import { PlaceSchemaService } from '@src/geo/place.schema'
+import { PlaceService } from '@src/geo/place.service'
+import { ComponentSchemaService } from '@src/process/component.schema'
+import { ComponentService } from '@src/process/component.service'
+import { ProcessSchemaService } from '@src/process/process.schema'
+import { ProcessService } from '@src/process/process.service'
+import { ProgramSchemaService } from '@src/process/program.schema'
+import { ProgramService } from '@src/process/program.service'
+import { CategorySchemaService } from '@src/product/category.schema'
+import { CategoryService } from '@src/product/category.service'
+import { ItemSchemaService } from '@src/product/item.schema'
+import { ItemService } from '@src/product/item.service'
+import { VariantSchemaService } from '@src/product/variant.schema'
+import { VariantService } from '@src/product/variant.service'
+import { SearchService } from '@src/search/search.service'
+import { OrgSchemaService } from '@src/users/org.schema'
+import { OrgService } from '@src/users/org.service'
+
+export interface McpToolContext {
+  userID: string
+  reqUser: ReqUser
+  /** The raw Express request already authenticated by the global AuthGuard - reused as the
+   * GraphQL contextValue so graphql_query's in-process execution runs under the same identity. */
+  rawReq: Request
+  schema: GraphQLSchema
+  /** Used to run graphql_query through Apollo's real plugin pipeline (rate limiting, caching,
+   * error formatting) instead of calling graphql-js's execute() directly against the schema. */
+  apolloServer: ApolloServer<BaseContext>
+  transform: TransformService
+  changeService: ChangeService
+  changeSchemaService: ChangeSchemaService
+  refEditService: RefEditService
+  searchService: SearchService
+  itemService: ItemService
+  itemSchemaService: ItemSchemaService
+  processService: ProcessService
+  processSchemaService: ProcessSchemaService
+  variantService: VariantService
+  variantSchemaService: VariantSchemaService
+  categoryService: CategoryService
+  categorySchemaService: CategorySchemaService
+  placeService: PlaceService
+  placeSchemaService: PlaceSchemaService
+  orgService: OrgService
+  orgSchemaService: OrgSchemaService
+  componentService: ComponentService
+  componentSchemaService: ComponentSchemaService
+  programService: ProgramService
+  programSchemaService: ProgramSchemaService
+}
+
+export interface McpToolTextResult {
+  [key: string]: unknown
+  content: { type: 'text'; text: string }[]
+  isError?: boolean
+  structuredContent?: Record<string, unknown>
+}
+
+export function textResult(value: unknown): McpToolTextResult {
+  return {
+    content: [
+      { type: 'text', text: typeof value === 'string' ? value : JSON.stringify(value, null, 2) },
+    ],
+  }
+}
+
+export function structuredResult(value: Record<string, unknown>): McpToolTextResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value, null, 2) }],
+    structuredContent: value,
+  }
+}
+
+export function errorResult(message: string): McpToolTextResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  }
+}
+
+export async function assertChangeIsDraft(
+  changeService: ChangeService,
+  changeID: string,
+): Promise<{ ok: true } | { ok: false; error: McpToolTextResult }> {
+  const change = await changeService.findOne(changeID)
+  if (change.status !== ChangeStatus.DRAFT) {
+    return {
+      ok: false,
+      error: errorResult(
+        `Change "${changeID}" is not in DRAFT status (currently ${change.status}). Move it back to DRAFT with edit_change before proposing further edits.`,
+      ),
+    }
+  }
+  return { ok: true }
+}

--- a/apps/api/src/mcp/tools/begin-change.tool.ts
+++ b/apps/api/src/mcp/tools/begin-change.tool.ts
@@ -1,0 +1,39 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z, ZodError } from 'zod/v4'
+
+import { CreateChangeInput } from '@src/changes/change-ext.model'
+import { ChangeStatus } from '@src/changes/change.entity'
+import { errorResult, McpToolContext, textResult } from '@src/mcp/mcp.types'
+
+export function registerBeginChangeTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'begin_change',
+    {
+      description:
+        'Create a new Change container to hold a set of draft edits. Every write made through ' +
+        'propose_edit/propose_refs must be attached to a Change created here. The change starts in ' +
+        'DRAFT status - keep using propose_edit/propose_refs to build it up, then use edit_change to ' +
+        'move it to PROPOSED when ready for human review.',
+      inputSchema: {
+        title: z.string().max(1000).optional().describe('Short title for the change.'),
+        description: z
+          .string()
+          .max(100000)
+          .optional()
+          .describe('Longer description of the change.'),
+      },
+    },
+    async (input) => {
+      try {
+        const parsed = await ctx.changeSchemaService.parseCreateInput(input as CreateChangeInput)
+        const change = await ctx.changeService.create(parsed, ctx.userID)
+        return textResult({ changeID: change.id, status: ChangeStatus.DRAFT, title: change.title })
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return errorResult(`Invalid input: ${error.message}`)
+        }
+        throw error
+      }
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/edit-change.tool.ts
+++ b/apps/api/src/mcp/tools/edit-change.tool.ts
@@ -1,0 +1,44 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z, ZodError } from 'zod/v4'
+
+import { UpdateChangeInput } from '@src/changes/change.model'
+import { errorResult, McpToolContext, textResult } from '@src/mcp/mcp.types'
+
+export function registerEditChangeTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'edit_change',
+    {
+      description:
+        "Update a Change's metadata (title/description/sources) and/or move its status between " +
+        'DRAFT and PROPOSED. Moving to PROPOSED signals the change is ready for human review and ' +
+        'locks it: propose_edit/propose_refs will refuse further edits until it is moved back to ' +
+        'DRAFT. This tool cannot set APPROVED/REJECTED/MERGED - those happen through the human ' +
+        'review/merge flow, not MCP.',
+      inputSchema: {
+        changeID: z.string().min(1).describe('The Change ID to update.'),
+        title: z.string().max(1000).optional(),
+        description: z.string().max(100000).optional(),
+        status: z.enum(['DRAFT', 'PROPOSED']).optional(),
+        sources: z.array(z.string()).optional().describe('Full replacement list of source IDs.'),
+      },
+    },
+    async ({ changeID, title, description, status, sources }) => {
+      try {
+        const parsed = await ctx.changeSchemaService.parseUpdateInput({
+          id: changeID,
+          title,
+          description,
+          status,
+          sources,
+        } as UpdateChangeInput)
+        const change = await ctx.changeService.update(parsed)
+        return textResult({ changeID: change.id, status: change.status, title: change.title })
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return errorResult(`Invalid input: ${error.message}`)
+        }
+        throw error
+      }
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/graphql-introspection.tool.ts
+++ b/apps/api/src/mcp/tools/graphql-introspection.tool.ts
@@ -1,0 +1,37 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { printSchema, printType } from 'graphql'
+import { z } from 'zod/v4'
+
+import { errorResult, McpToolContext, textResult } from '@src/mcp/mcp.types'
+
+export function registerGraphqlIntrospectionTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'graphql_introspection',
+    {
+      description:
+        'Inspect the Sage GraphQL schema as SDL (types, fields, args, enums) so you can write ' +
+        'correct queries for graphql_query. Omit "typeName" to get the entire schema; pass a ' +
+        'specific type name (e.g. "Query", "Item", "SearchType") to get just that definition - ' +
+        'much shorter, prefer this once you know what you are looking for.',
+      inputSchema: {
+        typeName: z
+          .string()
+          .optional()
+          .describe(
+            'A specific type name to print (e.g. "Query", "Item"). Omit for the full schema.',
+          ),
+      },
+    },
+    async ({ typeName }) => {
+      if (!typeName) {
+        return textResult(printSchema(ctx.schema))
+      }
+
+      const type = ctx.schema.getType(typeName)
+      if (!type) {
+        return errorResult(`Type "${typeName}" not found in the schema.`)
+      }
+      return textResult(printType(type))
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/graphql-query.tool.ts
+++ b/apps/api/src/mcp/tools/graphql-query.tool.ts
@@ -1,0 +1,68 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { parse } from 'graphql'
+import { z } from 'zod/v4'
+
+import { errorResult, McpToolContext } from '@src/mcp/mcp.types'
+
+export function registerGraphqlQueryTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'graphql_query',
+    {
+      description:
+        'Run a read-only GraphQL query against the Sage API - the same schema, resolvers, rate ' +
+        'limiting, and caching the web app uses. Runs as the currently authenticated user, subject ' +
+        'to the same field-level permissions as the rest of the API. Only "query" operations are ' +
+        'accepted - mutations and subscriptions are rejected. Use graphql_introspection first if ' +
+        'you need to see the schema (types, fields, args) before writing a query. For writes, use ' +
+        'begin_change / edit_change / propose_edit / propose_refs instead - those are the only ' +
+        'write path exposed here, and every write goes through the Change/Edit human-review ' +
+        'workflow rather than mutating live data.',
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .describe('A GraphQL document containing one or more query operations.'),
+        variables: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe('Variables referenced by the query.'),
+        operationName: z
+          .string()
+          .optional()
+          .describe('Required only if "query" defines more than one named operation.'),
+      },
+    },
+    async ({ query, variables, operationName }) => {
+      try {
+        const document = parse(query)
+        const nonQueryOp = document.definitions.find(
+          (def) => def.kind === 'OperationDefinition' && def.operation !== 'query',
+        )
+        if (nonQueryOp) {
+          return errorResult(
+            'Only "query" operations are allowed through graphql_query. Mutations and ' +
+              'subscriptions are rejected - use begin_change/edit_change/propose_edit/propose_refs ' +
+              'for writes.',
+          )
+        }
+      } catch (error) {
+        return errorResult(`GraphQL syntax error: ${(error as Error).message}`)
+      }
+
+      const response = await ctx.apolloServer.executeOperation(
+        { query, variables, operationName },
+        { contextValue: { req: ctx.rawReq } },
+      )
+
+      if (response.body.kind !== 'single') {
+        return errorResult('Incremental delivery responses (@defer/@stream) are not supported.')
+      }
+
+      const { data, errors } = response.body.singleResult
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ data, errors }, null, 2) }],
+        isError: Boolean(errors?.length),
+      }
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/propose-edit.tool.ts
+++ b/apps/api/src/mcp/tools/propose-edit.tool.ts
@@ -1,0 +1,164 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z, ZodError } from 'zod/v4'
+
+import { EditModelType } from '@src/changes/change.enum'
+import { Change } from '@src/changes/change.model'
+import { Place } from '@src/geo/place.model'
+import { assertChangeIsDraft, errorResult, McpToolContext, textResult } from '@src/mcp/mcp.types'
+import { Component } from '@src/process/component.model'
+import { Process } from '@src/process/process.model'
+import { Program } from '@src/process/program.model'
+import { Category } from '@src/product/category.model'
+import { Item } from '@src/product/item.model'
+import { Variant } from '@src/product/variant.model'
+import { Org } from '@src/users/org.model'
+
+// Material has no create/update mutation anywhere in this app (it isn't a valid `model` for
+// ref edits either) - it's read-only, same as Region, so it's intentionally absent here.
+export const MODEL_BY_EDIT_TYPE: Partial<Record<EditModelType, new () => any>> = {
+  [EditModelType.Place]: Place,
+  [EditModelType.Org]: Org,
+  [EditModelType.Component]: Component,
+  [EditModelType.Process]: Process,
+  [EditModelType.Program]: Program,
+  [EditModelType.Category]: Category,
+  [EditModelType.Item]: Item,
+  [EditModelType.Variant]: Variant,
+}
+
+type DispatchEntry = {
+  model: new () => any
+  schemaService: {
+    parseCreateInput(input: any): Promise<any>
+    parseUpdateInput(input: any): Promise<any>
+  }
+  entityService: {
+    create(input: any, userID: string): Promise<any>
+    update(input: any, userID: string): Promise<any>
+  }
+}
+
+function buildDispatch(ctx: McpToolContext): Partial<Record<EditModelType, DispatchEntry>> {
+  return {
+    [EditModelType.Place]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Place]!,
+      schemaService: ctx.placeSchemaService,
+      entityService: ctx.placeService,
+    },
+    [EditModelType.Org]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Org]!,
+      schemaService: ctx.orgSchemaService,
+      entityService: ctx.orgService,
+    },
+    [EditModelType.Component]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Component]!,
+      schemaService: ctx.componentSchemaService,
+      entityService: ctx.componentService,
+    },
+    [EditModelType.Process]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Process]!,
+      schemaService: ctx.processSchemaService,
+      entityService: ctx.processService,
+    },
+    [EditModelType.Program]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Program]!,
+      schemaService: ctx.programSchemaService,
+      entityService: ctx.programService,
+    },
+    [EditModelType.Category]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Category]!,
+      schemaService: ctx.categorySchemaService,
+      entityService: ctx.categoryService,
+    },
+    [EditModelType.Item]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Item]!,
+      schemaService: ctx.itemSchemaService,
+      entityService: ctx.itemService,
+    },
+    [EditModelType.Variant]: {
+      model: MODEL_BY_EDIT_TYPE[EditModelType.Variant]!,
+      schemaService: ctx.variantSchemaService,
+      entityService: ctx.variantService,
+    },
+  }
+}
+
+export function registerProposeEditTool(server: McpServer, ctx: McpToolContext) {
+  const dispatch = buildDispatch(ctx)
+
+  server.registerTool(
+    'propose_edit',
+    {
+      description:
+        'Create or update an entity (Place, Org, Component, Process, Program, Category, Item, or ' +
+        'Variant) as a draft edit tied to a Change created with begin_change. This never mutates ' +
+        'live data directly - it stages an edit inside the Change for human review, exactly like a ' +
+        'human editor using the web UI. The Change must be in DRAFT status (see begin_change / ' +
+        'edit_change); once PROPOSED, this tool refuses further edits until moved back to DRAFT. For ' +
+        'mode "update", "data" must include the entity "id". Material is read-only (like Region) - ' +
+        'it has no create/update mutation in this app.',
+      inputSchema: {
+        model: z
+          .enum(EditModelType)
+          .describe(
+            'Which entity type to create or update. Material is not supported - read-only.',
+          ),
+        mode: z.enum(['create', 'update']),
+        changeID: z
+          .string()
+          .min(1)
+          .describe('The Change (from begin_change) this edit is attached to. Must be DRAFT.'),
+        data: z
+          .record(z.string(), z.unknown())
+          .describe(
+            "Entity-specific fields matching the model's Create/Update input (e.g. name, desc). " +
+              'For mode "update", must include "id".',
+          ),
+      },
+    },
+    async ({ model, mode, changeID, data }) => {
+      const draftCheck = await assertChangeIsDraft(ctx.changeService, changeID)
+      if (!draftCheck.ok) return draftCheck.error
+
+      const entry = dispatch[model]
+      if (!entry) return errorResult(`Unsupported model type "${model}"`)
+
+      const resultKey = model.toLowerCase()
+
+      try {
+        if (mode === 'create') {
+          const parsed = await entry.schemaService.parseCreateInput({ ...data, changeID })
+          const result = await entry.entityService.create(parsed, ctx.userID)
+          return await formatResult(ctx, entry.model, resultKey, result)
+        }
+
+        if (!('id' in data) || typeof data.id !== 'string') {
+          return errorResult('mode "update" requires "id" in data')
+        }
+        const parsed = await entry.schemaService.parseUpdateInput({ ...data, changeID })
+        const result = await entry.entityService.update(parsed, ctx.userID)
+        return await formatResult(ctx, entry.model, resultKey, result)
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return errorResult(`Invalid input: ${error.message}`)
+        }
+        throw error
+      }
+    },
+  )
+}
+
+async function formatResult(
+  ctx: McpToolContext,
+  model: new () => any,
+  resultKey: string,
+  result: Record<string, any>,
+) {
+  const entity = result[resultKey]
+  const change = result.change
+
+  return textResult({
+    entity: entity ? await ctx.transform.entityToModel(model, entity) : undefined,
+    change: change ? await ctx.transform.entityToModel(Change, change) : undefined,
+  })
+}

--- a/apps/api/src/mcp/tools/propose-refs.tool.ts
+++ b/apps/api/src/mcp/tools/propose-refs.tool.ts
@@ -1,0 +1,87 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z, ZodError } from 'zod/v4'
+
+import { EditModelType, RefModelType } from '@src/changes/change.enum'
+import { Change } from '@src/changes/change.model'
+import { AddRefInput } from '@src/changes/ref-edit.model'
+import { assertChangeIsDraft, errorResult, McpToolContext, textResult } from '@src/mcp/mcp.types'
+import { MODEL_BY_EDIT_TYPE } from '@src/mcp/tools/propose-edit.tool'
+
+const RefEntrySchema = z.object({
+  refModel: z.enum(RefModelType).describe('The type of entity being referenced.'),
+  refField: z
+    .string()
+    .optional()
+    .describe('Disambiguates when an entity has multiple ref fields of the same refModel.'),
+  ref: z.string().optional().describe('A single referenced entity ID.'),
+  refs: z.array(z.string()).optional().describe('Multiple referenced entity IDs.'),
+  input: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Extra fields for a single ref (e.g. pivot metadata).'),
+  inputs: z
+    .array(z.record(z.string(), z.unknown()))
+    .optional()
+    .describe('Extra fields per ref, aligned with "refs".'),
+})
+
+export function registerProposeRefsTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'propose_refs',
+    {
+      description:
+        'Add relationship edits (e.g. link a Tag, an Item to a Variant) for one entity, as a draft ' +
+        'edit tied to a Change created with begin_change. Accepts multiple ref operations for the ' +
+        'same entity in one call. The Change must be in DRAFT status - once PROPOSED, this tool ' +
+        'refuses further edits until moved back to DRAFT.',
+      inputSchema: {
+        model: z
+          .enum(EditModelType)
+          .describe('The type of the entity whose refs are being edited.'),
+        id: z.string().min(1).describe('The ID of the entity whose refs are being edited.'),
+        changeID: z
+          .string()
+          .min(1)
+          .describe('The Change (from begin_change) this edit is attached to. Must be DRAFT.'),
+        refs: z.array(RefEntrySchema).min(1).describe('One or more ref operations to apply.'),
+      },
+    },
+    async ({ model, id, changeID, refs }) => {
+      const draftCheck = await assertChangeIsDraft(ctx.changeService, changeID)
+      if (!draftCheck.ok) return draftCheck.error
+
+      const modelClass = MODEL_BY_EDIT_TYPE[model]
+      if (!modelClass) return errorResult(`Unsupported model type "${model}"`)
+
+      const results = []
+      for (const refEntry of refs) {
+        try {
+          const parsed = await ctx.changeSchemaService.parseAddRefInput({
+            ...refEntry,
+            changeID,
+          } as AddRefInput)
+          const output = await ctx.refEditService.addRef(model, id, parsed, ctx.userID)
+          results.push({
+            ok: true,
+            entity: output.model
+              ? await ctx.transform.entityToModel(modelClass, output.model as any)
+              : undefined,
+            change: output.change
+              ? await ctx.transform.entityToModel(Change, output.change as any)
+              : undefined,
+          })
+        } catch (error) {
+          if (error instanceof ZodError) {
+            results.push({ ok: false, error: `Invalid input: ${error.message}` })
+          } else if (error instanceof Error) {
+            results.push({ ok: false, error: error.message })
+          } else {
+            throw error
+          }
+        }
+      }
+
+      return textResult({ results })
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/search-catalog.tool.ts
+++ b/apps/api/src/mcp/tools/search-catalog.tool.ts
@@ -1,0 +1,112 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod/v4'
+
+import { McpToolContext, structuredResult } from '@src/mcp/mcp.types'
+import { SearchType } from '@src/search/search.model'
+
+const QUERY_FILTER_DSL_DOCS = `
+The "query" string supports an embedded token:value filter syntax that is parsed out before
+free-text search runs. Anything matching "token:value" (or "token:=value", "token:!=value",
+"token=value") is stripped from the free text and turned into an exact/comparison filter. Only
+use tokens from this table - an unrecognized "word:value" token is silently dropped from BOTH the
+filter and the free-text query, contributing nothing:
+
+| token                   | applies to (SearchType) | operators                              |
+|-------------------------|--------------------------|-----------------------------------------|
+| code                    | variant                  | : := :!= =                              |
+| components              | variant                  | : := :!= =                              |
+| items                   | variant                  | : := :!= =                              |
+| categories              | item                      | : := :!= =                              |
+| tags                    | variant, place, item, component | : := :!= =                       |
+| placetype               | region                    | : := :!= =                              |
+| admin_level             | region                    | : := :!= = > >= < <= (numeric)          |
+| technical               | material                  | : := :!= =                              |
+| shape                   | material                  | : := :!= =                              |
+| ancestors               | material                  | : := :!= =                              |
+| technical_descendants   | material                  | : := :!= =                              |
+
+Syntax: "token:value" (contains-match), "token:=value" (exact), "token:!=value" (exact-exclude),
+"token=value" (equal). No space between token/operator/value. Quote multi-word values
+(tags:"heavy duty"). Example: "code:373933232" is a precise barcode lookup for a variant -
+dramatically more reliable than free-text fuzzy matching for that use case.
+`.trim()
+
+export function registerSearchCatalogTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'search_catalog',
+    {
+      description: `Search the catalog (items, variants, materials, processes, categories, places, regions, orgs, components).
+
+${QUERY_FILTER_DSL_DOCS}
+
+"filters" (separate from the query DSL above) lets you facet-filter by exact field/value pairs,
+but the set of filterable fields differs per entity type and isn't fixed - call this tool once
+with just "query" (and optionally "types") to get results AND a "facets" array describing which
+fields are filterable for this result set and their possible values, then call again with
+"filters" populated using the exact "field"/"value" strings from that response. Never guess a
+filter field/value that didn't come from a prior response's facets.`,
+      inputSchema: {
+        query: z
+          .string()
+          .describe(
+            'Free-text search query, optionally containing token:value filter syntax (see tool description).',
+          ),
+        types: z
+          .array(z.enum(SearchType))
+          .optional()
+          .describe('Restrict results to these entity types. Omit to search all types.'),
+        limit: z.number().int().positive().optional().describe('Max results to return.'),
+        offset: z.number().int().min(0).optional().describe('Offset for pagination.'),
+        filters: z
+          .array(z.object({ field: z.string(), values: z.array(z.string()).min(1) }))
+          .optional()
+          .describe(
+            'Facet filters using field/value strings taken verbatim from a prior response\'s "facets" array.',
+          ),
+      },
+      outputSchema: {
+        items: z.array(z.record(z.string(), z.unknown())),
+        totalCount: z.number(),
+        facets: z.array(
+          z.object({
+            field: z.string(),
+            counts: z.array(z.object({ value: z.string(), count: z.number() })),
+          }),
+        ),
+      },
+    },
+    async ({ query, types, limit, offset, filters }) => {
+      const cursor = await ctx.searchService.searchAll(
+        query,
+        types,
+        undefined,
+        limit,
+        offset,
+        filters,
+      )
+      const result = {
+        items: [] as Record<string, unknown>[],
+        totalCount: 0,
+        facets: [] as { field: string; counts: { value: string; count: number }[] }[],
+      }
+
+      if (!cursor) {
+        return structuredResult(result)
+      }
+
+      result.items = await Promise.all(
+        cursor.items.map(async (item) => {
+          const model = await ctx.transform.entityToModel(item._type, item)
+          return JSON.parse(JSON.stringify(model)) as Record<string, unknown>
+        }),
+      )
+      result.totalCount = cursor.count
+      result.facets = (cursor.facets ?? []).map((f) => ({
+        field: f.field,
+        counts: f.counts.map((c) => ({ value: c.value, count: c.count })),
+      }))
+
+      return structuredResult(result)
+    },
+  )
+}

--- a/apps/api/src/mcp/tools/whoami.tool.ts
+++ b/apps/api/src/mcp/tools/whoami.tool.ts
@@ -1,0 +1,21 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+import { McpToolContext, textResult } from '@src/mcp/mcp.types'
+
+export function registerWhoamiTool(server: McpServer, ctx: McpToolContext) {
+  server.registerTool(
+    'whoami',
+    {
+      description:
+        'Return the identity of the currently authenticated user making this MCP request.',
+      inputSchema: {},
+    },
+    async () => {
+      return textResult({
+        id: ctx.reqUser.id,
+        name: ctx.reqUser.name,
+        email: ctx.reqUser.email,
+      })
+    },
+  )
+}

--- a/apps/api/test/app-test.module.ts
+++ b/apps/api/test/app-test.module.ts
@@ -20,6 +20,7 @@ import { FeedbackModule } from '@src/feedback/feedback.module'
 import { GeoModule } from '@src/geo/geo.module'
 import { GraphQLModule } from '@src/graphql/graphql.module'
 import { HealthModule } from '@src/health/health.module'
+import { McpModule } from '@src/mcp/mcp.module'
 import { ProcessModule } from '@src/process/process.module'
 import { ProductModule } from '@src/product/product.module'
 import { SearchModule } from '@src/search/search.module'
@@ -79,6 +80,7 @@ if (dotenv) {
     SearchModule,
     FeedModule,
     FeedbackModule,
+    McpModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }, AppService],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@mistralai/mistralai':
         specifier: ^2.2.0
         version: 2.2.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@nestjs/apollo':
         specifier: ^13.2.4
         version: 13.2.4(722676294ad96a8b47266d5aaac720b2)
@@ -3226,6 +3229,16 @@ packages:
 
   '@mistralai/mistralai@2.2.0':
     resolution: {integrity: sha512-JQUGIXjFWnw/J9LpTSf/ZXwVW3Sh8FBAcfTo5QvAHqkl4CfSiIwnjRJhMoAFcP6ncCe84YPU1ncDGX+p3OXnfg==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@mongodb-js/saslprep@1.4.6':
     resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
@@ -9069,9 +9082,17 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
     engines: {node: '>=12.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -9084,6 +9105,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -9789,6 +9816,10 @@ packages:
   iota-array@1.0.0:
     resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
 
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -10082,6 +10113,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -11323,6 +11357,10 @@ packages:
 
   piscina@4.9.2:
     resolution: {integrity: sha512-Fq0FERJWFEUpB4eSY59wSNwXD4RYqR+nR/WiEVcZW8IWfVBxJJafcgTEZDQo8k3w0sUarJ8RyVbbUF4GQ2LGbQ==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -15933,7 +15971,6 @@ snapshots:
   '@hono/node-server@1.19.9(hono@4.11.4)':
     dependencies:
       hono: 4.11.4
-    optional: true
 
   '@humanfs/core@0.19.1': {}
 
@@ -16545,6 +16582,28 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.11.4)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.0(express@5.2.1)
+      hono: 4.11.4
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@mongodb-js/saslprep@1.4.6':
     dependencies:
@@ -23049,7 +23108,13 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
   eventsource@2.0.2: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
 
   execa@5.1.1:
     dependencies:
@@ -23076,6 +23141,14 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.6.0(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   express@5.2.1:
     dependencies:
@@ -23693,8 +23766,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.11.4:
-    optional: true
+  hono@4.11.4: {}
 
   hookable@5.5.3: {}
 
@@ -23856,6 +23928,8 @@ snapshots:
 
   iota-array@1.0.0:
     optional: true
+
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -24139,6 +24213,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -25726,6 +25802,8 @@ snapshots:
   piscina@4.9.2:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an MCP server at `/mcp` that streams JSON-RPC responses over SSE and exposes tools for catalog search, read-only GraphQL, and proposing changes. Secured by existing auth plus a new per-user POST rate limit.

- **New Features**
  - New `/mcp` endpoint using the MCP HTTP transport; streams responses via SSE.
  - Tools: `whoami`, `search_catalog` (facets + structured output), `graphql_introspection`, `graphql_query` (query-only; runs through Apollo plugins), `begin_change`, `edit_change` (DRAFT/PROPOSED), `propose_edit`, `propose_refs` (edits blocked unless change is DRAFT).
  - Integrated with the live GraphQL schema and Apollo server context to enforce permissions, rate limits, and caching.
  - New `McpRateLimitGuard` throttles POSTs per authenticated user and returns `Retry-After`; GET/DELETE return 405.
  - Integration tests cover auth, tool listing, GraphQL validation, search output, and change/edit flows.

- **Dependencies**
  - Added `@modelcontextprotocol/sdk` (v1.29.0).

<sup>Written for commit d859de6c43a6b6d9a7fa13a73654f95501618306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

