### PR TITLE
auth: Fix frontend sign_in/consent

### DIFF
--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -29,6 +29,7 @@ import { AuthService } from '@src/auth/auth.service'
 import { AuthUserService } from '@src/auth/authuser.service'
 import { SkipBodyParsingMiddleware } from '@src/auth/middlewares'
 import { OAuthResourceController } from '@src/auth/oauth-resource.controller'
+import { OAuthServerMetadataController } from '@src/auth/oauth-server-metadata.controller'
 import { AFTER_HOOK_KEY, BEFORE_HOOK_KEY, HOOK_KEY } from '@src/auth/symbols'
 
 const HOOKS = [
@@ -231,7 +232,7 @@ class AuthModuleWithoutControllers extends BetterAuthModule {
       inject: [MikroORM],
     }),
   ],
-  controllers: [OAuthResourceController],
+  controllers: [OAuthResourceController, OAuthServerMetadataController],
   providers: [AuthUserService],
   exports: [AuthUserService, BetterAuthModule],
 })

--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -2,7 +2,7 @@ import { apiKey } from '@better-auth/api-key'
 import { oauthProvider } from '@better-auth/oauth-provider'
 import { MikroORM } from '@mikro-orm/postgresql'
 import { betterAuth } from 'better-auth'
-import { admin, jwt, organization, username } from 'better-auth/plugins'
+import { admin, jwt, organization, testUtils, username } from 'better-auth/plugins'
 import { Kysely } from 'kysely'
 import { KyselyKnexDialect, PGColdDialect } from 'kysely-knex'
 
@@ -130,6 +130,7 @@ export const configureAuth = (orm: MikroORM) => {
         allowUnauthenticatedClientRegistration: true,
         scopes: ['openid', 'profile', 'email', 'offline_access'],
         validAudiences: [getApiOrigin()],
+        silenceWarnings: { oauthAuthServerConfig: true },
         schema: {
           oauthClient: {
             modelName: 'auth.oauth_clients',
@@ -190,6 +191,7 @@ export const configureAuth = (orm: MikroORM) => {
           },
         },
       }),
+      ...(process.env.NODE_ENV === 'test' ? [testUtils()] : []),
     ],
     user: {
       modelName: 'users',

--- a/apps/api/src/auth/oauth-provider.e2e.spec.ts
+++ b/apps/api/src/auth/oauth-provider.e2e.spec.ts
@@ -1,0 +1,126 @@
+import crypto from 'node:crypto'
+
+import { MikroORM } from '@mikro-orm/postgresql'
+import { INestApplication } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { AppTestModule } from '@test/app-test.module'
+import type { TestHelpers } from 'better-auth/plugins'
+import request from 'supertest'
+
+import { AuthModuleOptions, MODULE_OPTIONS_TOKEN } from '@src/auth/auth-module-definition'
+import { BaseSeeder } from '@src/db/seeds/BaseSeeder'
+import { UserSeeder } from '@src/db/seeds/UserSeeder'
+import { clearDatabase } from '@src/db/test.utils'
+import { User } from '@src/users/users.entity'
+
+describe('OAuth provider (integration)', () => {
+  let app: INestApplication
+  let orm: MikroORM
+  let testHelpers: TestHelpers
+  let cookieHeader: string
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppTestModule],
+    }).compile()
+
+    app = module.createNestApplication()
+    // Bind to the same host:port as BETTER_AUTH_URL (see .env.test.local), matching
+    // jwt-jwks.spec.ts: better-auth resolves the issuer from BETTER_AUTH_URL at startup.
+    await app.listen(4444, '127.0.0.1')
+
+    orm = module.get<MikroORM>(MikroORM)
+    const authOptions = module.get<AuthModuleOptions>(MODULE_OPTIONS_TOKEN)
+
+    await clearDatabase(orm, 'auth')
+    await clearDatabase(orm, 'public')
+    await orm.seeder.seed(BaseSeeder, UserSeeder)
+
+    // `testUtils()` is only added to the plugins array under NODE_ENV=test (see
+    // configureAuth), so `ctx.test` isn't statically typed on `$context` — cast it.
+    const ctx = (await authOptions.auth.$context) as unknown as { test: TestHelpers }
+    testHelpers = ctx.test
+
+    const user = await orm.em.fork().findOneOrFail(User, { username: 'user' })
+    const cookies = await testHelpers.getCookies({ userId: user.id })
+    cookieHeader = cookies.map((c) => `${c.name}=${c.value}`).join('; ')
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  test('GET /.well-known/oauth-authorization-server/auth returns RFC 8414 metadata', async () => {
+    const res = await request(app.getHttpServer()).get(
+      '/.well-known/oauth-authorization-server/auth',
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body.issuer).toMatch(/\/auth$/)
+    expect(res.body.authorization_endpoint).toMatch(/\/auth\/oauth2\/authorize$/)
+    expect(res.body.token_endpoint).toMatch(/\/auth\/oauth2\/token$/)
+    expect(res.body.registration_endpoint).toMatch(/\/auth\/oauth2\/register$/)
+  })
+
+  test('full authorize -> consent -> token round trip using a dynamically registered client', async () => {
+    const registerRes = await request(app.getHttpServer())
+      .post('/auth/oauth2/register')
+      .send({
+        redirect_uris: ['https://client.example.com/callback'],
+        token_endpoint_auth_method: 'none',
+      })
+    expect(registerRes.status).toBe(200)
+    const clientId: string = registerRes.body.client_id
+    const redirectUri: string = registerRes.body.redirect_uris[0]
+    expect(clientId).toBeTruthy()
+
+    const codeVerifier = crypto.randomBytes(32).toString('base64url')
+    const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url')
+
+    const authorizeRes = await request(app.getHttpServer())
+      .get('/auth/oauth2/authorize')
+      .set('Cookie', cookieHeader)
+      .set('Accept', 'application/json')
+      .query({
+        response_type: 'code',
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        scope: 'openid profile email',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+
+    expect(authorizeRes.status).toBe(200)
+    expect(authorizeRes.body.redirect).toBe(true)
+    const consentUrl = new URL(authorizeRes.body.url)
+    expect(consentUrl.pathname).toBe('/oauth/consent')
+
+    const consentRes = await request(app.getHttpServer())
+      .post('/auth/oauth2/consent')
+      .set('Cookie', cookieHeader)
+      .set('Accept', 'application/json')
+      .send({ accept: true, oauth_query: consentUrl.search.slice(1) })
+
+    expect(consentRes.status).toBe(200)
+    const redirectWithCode = new URL(consentRes.body.url)
+    expect(redirectWithCode.origin + redirectWithCode.pathname).toBe(redirectUri)
+    const code = redirectWithCode.searchParams.get('code')
+    expect(code).toBeTruthy()
+
+    const tokenRes = await request(app.getHttpServer())
+      .post('/auth/oauth2/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        code,
+        code_verifier: codeVerifier,
+        redirect_uri: redirectUri,
+      })
+
+    expect(tokenRes.status).toBe(200)
+    expect(typeof tokenRes.body.access_token).toBe('string')
+    expect(tokenRes.body.access_token.length).toBeGreaterThan(0)
+    expect(typeof tokenRes.body.id_token).toBe('string')
+  })
+})

--- a/apps/api/src/auth/oauth-server-metadata.controller.ts
+++ b/apps/api/src/auth/oauth-server-metadata.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Header } from '@nestjs/common'
+
+import { AuthService } from '@src/auth/auth.service'
+import { AllowAnonymous } from '@src/auth/decorators'
+
+@Controller('.well-known/oauth-authorization-server/auth')
+export class OAuthServerMetadataController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Get()
+  @AllowAnonymous()
+  @Header('Cache-Control', 'public, max-age=3600')
+  async getAuthServerMetadata() {
+    return this.authService.api.getOAuthServerConfig({})
+  }
+}

--- a/apps/frontend/app/pages/oauth/consent.vue
+++ b/apps/frontend/app/pages/oauth/consent.vue
@@ -38,8 +38,8 @@ const clientName = ref(clientId ?? 'An application')
 const formError = ref<string | null>(null)
 const submitting = ref(false)
 
-const session = auth.useSession()
-if (!session.value.data) {
+const { data: session } = await auth.getSession()
+if (!session) {
   router.replace(`/profile/sign_in?redirectTo=${encodeURIComponent(route.fullPath)}`)
 }
 

--- a/apps/frontend/app/pages/profile/sign_in.vue
+++ b/apps/frontend/app/pages/profile/sign_in.vue
@@ -78,10 +78,18 @@ useTopbar({ title: 'Sign In', back: 'true' })
 
 const auth = useAuthClient()
 const router = useRouter()
+const route = useRoute()
+
+const redirectTarget = computed(() => {
+  const target = route.query.redirectTo
+  return typeof target === 'string' && target.startsWith('/') && !target.startsWith('//')
+    ? target
+    : '/profile'
+})
 
 const session = auth.useSession()
 if (session.value.data) {
-  router.replace('/profile')
+  router.replace(redirectTarget.value)
 }
 const formError = ref<string | null>(null)
 
@@ -107,7 +115,7 @@ const form = useForm({
     }
     const session = await auth.getSession()
     if (session.data) {
-      router.replace('/profile')
+      router.replace(redirectTarget.value)
     }
   },
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the OAuth sign-in/consent redirect flow and exposes the auth server’s RFC 8414 metadata for discovery. Adds E2E coverage for dynamic client registration and the full code + PKCE flow.

- **Bug Fixes**
  - Consent page waits for `auth.getSession()`; unauthenticated users are sent to `/profile/sign_in?redirectTo=<current-path>`.
  - Sign-in now respects a safe `redirectTo` param (internal paths only) and uses it both if already signed in and after login.

- **New Features**
  - Adds `/.well-known/oauth-authorization-server/auth` endpoint (1h cache) via `OAuthServerMetadataController` and silences `oauthAuthServerConfig` warnings.
  - Test env enables `testUtils()` from `better-auth/plugins`; new integration spec covers discovery and a full register → authorize → consent → token flow.

<sup>Written for commit c6e4886c9e2ec05d94ea044c37ecb03509c06ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

