### PR TITLE
api: Add base domain for prod/dev envs

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -9,11 +9,12 @@ import { KyselyKnexDialect, PGColdDialect } from 'kysely-knex'
 import { DateCoercionKyselyPlugin } from '@src/auth/date-coercion-kysely.plugin'
 import { getApiOrigin } from '@src/auth/oauth.constants'
 import { reservedUsernames } from '@src/auth/reserved-usernames'
-import { isProd } from '@src/common/common.utils'
+import { getBaseDomain, isProd } from '@src/common/common.utils'
 
 export const configureAuth = (orm: MikroORM) => {
   const conn = orm.em.getConnection()
   const knex = conn.getKnex()
+  const baseDomain = getBaseDomain()
   return betterAuth({
     basePath: '/auth',
     database: {
@@ -120,12 +121,8 @@ export const configureAuth = (orm: MikroORM) => {
         },
       }),
       oauthProvider({
-        loginPage: isProd()
-          ? 'https://sageleaf.app/profile/sign_in'
-          : 'https://dev.sageleaf.app/profile/sign_in',
-        consentPage: isProd()
-          ? 'https://sageleaf.app/oauth/consent'
-          : 'https://dev.sageleaf.app/oauth/consent',
+        loginPage: `https://${baseDomain}/profile/sign_in`,
+        consentPage: `https://${baseDomain}/oauth/consent`,
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         scopes: ['openid', 'profile', 'email', 'offline_access'],
@@ -273,10 +270,8 @@ export const configureAuth = (orm: MikroORM) => {
     },
     trustedOrigins: isProd()
       ? [
-          'https://sageleaf.app',
-          'https://dev.sageleaf.app',
-          'https://science.sageleaf.app',
-          'https://science.dev.sageleaf.app',
+          `https://${baseDomain}`,
+          `https://science.${baseDomain}`,
           'http://localhost:*',
           'http://127.0.0.1:*',
           'https://tauri.localhost',
@@ -294,7 +289,7 @@ export const configureAuth = (orm: MikroORM) => {
       cookiePrefix: 'sage',
       crossSubDomainCookies: {
         enabled: isProd(),
-        domain: isProd() ? '.sageleaf.app' : undefined,
+        domain: isProd() ? `.${baseDomain}` : undefined,
       },
       defaultCookieAttributes: {
         secure: true,

--- a/apps/api/src/auth/oauth.constants.ts
+++ b/apps/api/src/auth/oauth.constants.ts
@@ -1,6 +1,6 @@
-import { isProd } from '@src/common/common.utils'
+import { getBaseDomain } from '@src/common/common.utils'
 
-const DEFAULT_ORIGIN = isProd() ? 'https://api.sageleaf.app' : 'https://api.dev.sageleaf.app'
+const DEFAULT_ORIGIN = `https://api.${getBaseDomain()}`
 
 /**
  * The origin better-auth itself uses to build issuer/audience claims (derived from

--- a/apps/api/src/common/common.utils.ts
+++ b/apps/api/src/common/common.utils.ts
@@ -1,1 +1,6 @@
 export const isProd = () => process.env.NODE_ENV === 'production'
+
+/**
+ * The base deployed domain (e.g. 'dev.sageleaf.app' or 'sageleaf.app')
+ */
+export const getBaseDomain = () => process.env.BASE_DOMAIN ?? 'dev.sageleaf.app'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralizes domain configuration for auth by introducing `getBaseDomain()` and replacing hardcoded prod/dev URLs. This makes OAuth pages, API origin, trusted origins, and cookie domains derive from a single `BASE_DOMAIN`.

- **Refactors**
  - Add `getBaseDomain()` in `common.utils` (reads `BASE_DOMAIN`, defaults to `dev.sageleaf.app`).
  - Set OAuth `loginPage`/`consentPage` to `https://${BASE_DOMAIN}/...`.
  - Set API origin to `https://api.${BASE_DOMAIN}` in `oauth.constants`.
  - Derive trusted origins (`https://${BASE_DOMAIN}`, `https://science.${BASE_DOMAIN}`) and cookie domain (`.${BASE_DOMAIN}`) when prod.

- **Migration**
  - Define `BASE_DOMAIN` in all environments:
    - Prod: `sageleaf.app`
    - Dev: `dev.sageleaf.app` (or your chosen dev base)
  - Ensure `api.${BASE_DOMAIN}` and `science.${BASE_DOMAIN}` DNS/hosts are configured.

<sup>Written for commit b003d855e220e943cb6777151a5c4867ee000ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

