### PR TITLE
api: Fix audience for MCP OAuth

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -17,6 +17,7 @@ export const configureAuth = (orm: MikroORM) => {
   const baseDomain = getBaseDomain()
   return betterAuth({
     basePath: '/auth',
+    disabledPaths: ['/token'],
     database: {
       db: new Kysely({
         dialect: new KyselyKnexDialect({
@@ -108,6 +109,7 @@ export const configureAuth = (orm: MikroORM) => {
         },
       }),
       jwt({
+        disableSettingJwtHeader: true,
         schema: {
           jwks: {
             modelName: 'auth.jwks',
@@ -126,7 +128,7 @@ export const configureAuth = (orm: MikroORM) => {
         allowDynamicClientRegistration: true,
         allowUnauthenticatedClientRegistration: true,
         scopes: ['openid', 'profile', 'email', 'offline_access'],
-        validAudiences: [getApiOrigin()],
+        validAudiences: [getApiOrigin(), `${getApiOrigin()}/`],
         silenceWarnings: { oauthAuthServerConfig: true },
         schema: {
           oauthClient: {

--- a/apps/api/src/auth/oauth-provider.e2e.spec.ts
+++ b/apps/api/src/auth/oauth-provider.e2e.spec.ts
@@ -8,6 +8,7 @@ import type { TestHelpers } from 'better-auth/plugins'
 import request from 'supertest'
 
 import { AuthModuleOptions, MODULE_OPTIONS_TOKEN } from '@src/auth/auth-module-definition'
+import { getApiOrigin } from '@src/auth/oauth.constants'
 import { BaseSeeder } from '@src/db/seeds/BaseSeeder'
 import { UserSeeder } from '@src/db/seeds/UserSeeder'
 import { clearDatabase } from '@src/db/test.utils'
@@ -77,6 +78,11 @@ describe('OAuth provider (integration)', () => {
     const codeVerifier = crypto.randomBytes(32).toString('base64url')
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url')
 
+    // MCP clients canonicalize the resource identifier through the `URL` API, which
+    // appends a trailing slash to a bare-origin URL (e.g. `new URL(origin).toString()`).
+    // Exercise that form here since it's what a spec-compliant client actually sends.
+    const resource = `${getApiOrigin()}/`
+
     const authorizeRes = await request(app.getHttpServer())
       .get('/auth/oauth2/authorize')
       .set('Cookie', cookieHeader)
@@ -88,6 +94,7 @@ describe('OAuth provider (integration)', () => {
         scope: 'openid profile email',
         code_challenge: codeChallenge,
         code_challenge_method: 'S256',
+        resource,
       })
 
     expect(authorizeRes.status).toBe(200)
@@ -116,11 +123,26 @@ describe('OAuth provider (integration)', () => {
         code,
         code_verifier: codeVerifier,
         redirect_uri: redirectUri,
+        resource,
       })
 
     expect(tokenRes.status).toBe(200)
     expect(typeof tokenRes.body.access_token).toBe('string')
     expect(tokenRes.body.access_token.length).toBeGreaterThan(0)
     expect(typeof tokenRes.body.id_token).toBe('string')
+  })
+
+  test('POST /auth/token (JWT plugin token endpoint) is disabled', async () => {
+    const res = await request(app.getHttpServer()).post('/auth/token').set('Cookie', cookieHeader)
+
+    expect(res.status).toBe(404)
+  })
+
+  test('GET /auth/get-session does not set the set-auth-jwt header', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/auth/get-session')
+      .set('Cookie', cookieHeader)
+
+    expect(res.headers['set-auth-jwt']).toBeUndefined()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix OAuth audience handling for MCP clients by accepting trailing-slash resources. Also hardens auth by disabling the JWT token endpoint and not setting the auth JWT header.

- **Bug Fixes**
  - Accept trailing-slash audience by adding `${getApiOrigin()}/` to `validAudiences`.
  - Disable JWT plugin token endpoint via `disabledPaths: ['/token']`.
  - Stop sending the `set-auth-jwt` response header (`disableSettingJwtHeader: true`).
  - E2E tests cover trailing-slash resource, disabled `/auth/token`, and missing `set-auth-jwt` header.

<sup>Written for commit fb0986774678a38b9efc5e8df09f45d31cad5c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

