### PR TITLE
api: disabledPaths breaks tests

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -17,7 +17,6 @@ export const configureAuth = (orm: MikroORM) => {
   const baseDomain = getBaseDomain()
   return betterAuth({
     basePath: '/auth',
-    disabledPaths: ['/token'],
     database: {
       db: new Kysely({
         dialect: new KyselyKnexDialect({

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -141,6 +141,13 @@
         "dependsOn": [
           "build"
         ]
+      },
+      "typecheck": {
+        "inputs": [
+          "{projectRoot}/tsconfig.json",
+          "{projectRoot}/**/*.ts",
+          "{projectRoot}/**/*.vue"
+        ]
       }
     }
   }

--- a/apps/science/package.json
+++ b/apps/science/package.json
@@ -128,6 +128,13 @@
         "dependsOn": [
           "build"
         ]
+      },
+      "typecheck": {
+        "inputs": [
+          "{projectRoot}/tsconfig.json",
+          "{projectRoot}/**/*.ts",
+          "{projectRoot}/**/*.vue"
+        ]
       }
     }
   }

--- a/packages/scanleaf/tsconfig.json
+++ b/packages/scanleaf/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "bundler",
     "strict": true,
     "declaration": true,
-    "declarationDir": "./dist-js",
+    "rootDir": "./guest-js",
     "outDir": "./dist-js",
     "skipLibCheck": true
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -124,6 +124,13 @@
         "dependsOn": [
           "build"
         ]
+      },
+      "typecheck": {
+        "inputs": [
+          "{projectRoot}/tsconfig.json",
+          "{projectRoot}/**/*.ts",
+          "{projectRoot}/**/*.vue"
+        ]
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix failing auth tests by removing the `disabledPaths` override that blocked the token route. Also adds typecheck pipeline inputs and aligns TypeScript output paths in `packages/scanleaf`.

- **Bug Fixes**
  - Remove `disabledPaths: ['/token']` from API auth config to restore the token endpoint and unblock tests.

- **Refactors**
  - Add a `typecheck` pipeline with file inputs in `apps/frontend`, `apps/science`, and `packages/ui`.
  - Set `rootDir` to `./guest-js` in `packages/scanleaf/tsconfig.json` to align emit paths with `outDir` (`./dist-js`).

<sup>Written for commit 3f3d1de00d163c45a44c81c1741d956f12e5b330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

