### PR TITLE
api: Fix jwks on verifyAccessToken

### DIFF
--- a/apps/api/src/auth/auth.guard.test.ts
+++ b/apps/api/src/auth/auth.guard.test.ts
@@ -86,6 +86,26 @@ describe('AuthGuard bearer token scopes', () => {
     expect(request.oauthScopes).toEqual(['process:write', 'offline_access'])
   })
 
+  it('verifies bearer tokens with an explicit jwksUrl', async () => {
+    // configureAuth() never sets betterAuth's `baseURL`, so the resource client can't
+    // derive a jwksUrl on its own (see jwt-jwks.spec.ts) — without passing one explicitly,
+    // local JWT verification is silently skipped and every bearer token fails with
+    // "no token payload", regardless of validity.
+    verifyAccessToken.mockResolvedValueOnce({
+      sub: 'user-1',
+      scope: 'process:write',
+    })
+
+    const { guard, context } = createGuard(['process:write'])
+
+    await guard.canActivate(context as never)
+
+    expect(verifyAccessToken).toHaveBeenCalledWith(
+      'test-token',
+      expect.objectContaining({ jwksUrl: 'https://auth.sageleaf.test/jwks' }),
+    )
+  })
+
   it('rejects bearer tokens missing a required OAuth scope', async () => {
     verifyAccessToken.mockResolvedValueOnce({
       sub: 'user-1',

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -289,6 +289,7 @@ export class AuthGuard implements CanActivate {
     try {
       const resourceClient = createResourceClient(this.options.auth)
       const payload = await resourceClient.verifyAccessToken(token, {
+        jwksUrl: `${getAuthIssuer()}/jwks`,
         verifyOptions: {
           issuer: getAuthIssuer(),
           audience: getApiOrigin(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Explicitly pass the JWKS URL to `verifyAccessToken` in the API `AuthGuard` so local JWT verification works and bearer tokens validate correctly. Adds a test to ensure the JWKS is provided and prevents the "no token payload" failure.

- **Bug Fixes**
  - Provide `jwksUrl: ${getAuthIssuer()}/jwks` when verifying access tokens, since the resource client can't derive it without a base URL.
  - Add a test that asserts `verifyAccessToken` is called with the explicit JWKS URL and that scoped tokens pass.

<sup>Written for commit b86be8eba29c2f875b5bc30aaeb1e6fd54df3f9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

