### PR TITLE
api: Add trusted proxies configuration

### DIFF
--- a/apps/api/src/auth/auth.ts
+++ b/apps/api/src/auth/auth.ts
@@ -9,7 +9,7 @@ import { KyselyKnexDialect, PGColdDialect } from 'kysely-knex'
 import { DateCoercionKyselyPlugin } from '@src/auth/date-coercion-kysely.plugin'
 import { getApiOrigin } from '@src/auth/oauth.constants'
 import { reservedUsernames } from '@src/auth/reserved-usernames'
-import { getBaseDomain, isProd } from '@src/common/common.utils'
+import { getBaseDomain, getTrustedProxies, isDev, isProd } from '@src/common/common.utils'
 
 export const configureAuth = (orm: MikroORM) => {
   const conn = orm.em.getConnection()
@@ -269,23 +269,13 @@ export const configureAuth = (orm: MikroORM) => {
           }
         : undefined,
     },
-    trustedOrigins: isProd()
-      ? [
-          `https://${baseDomain}`,
-          `https://science.${baseDomain}`,
-          'http://localhost:*',
-          'http://127.0.0.1:*',
-          'https://tauri.localhost',
-          'http://tauri.localhost',
-          'tauri://localhost',
-        ]
-      : [
-          'http://localhost:*',
-          'http://127.0.0.1:*',
-          'https://tauri.localhost',
-          'http://tauri.localhost',
-          'tauri://localhost',
-        ],
+    trustedOrigins: [
+      ...(isProd() ? [`https://${baseDomain}`, `https://science.${baseDomain}`] : []),
+      ...(isDev() ? ['http://localhost:*', 'http://127.0.0.1:*'] : []),
+      'https://tauri.localhost',
+      'http://tauri.localhost',
+      'tauri://localhost',
+    ],
     advanced: {
       cookiePrefix: 'sage',
       crossSubDomainCookies: {
@@ -297,6 +287,9 @@ export const configureAuth = (orm: MikroORM) => {
         httpOnly: true,
         sameSite: 'none',
         partitioned: true,
+      },
+      ipAddress: {
+        trustedProxies: getTrustedProxies(),
       },
     },
     hooks: {},

--- a/apps/api/src/common/common.utils.ts
+++ b/apps/api/src/common/common.utils.ts
@@ -1,6 +1,21 @@
 export const isProd = () => process.env.NODE_ENV === 'production'
 
 /**
+ * True for local dev and for the dev cluster deployment, which sets `IS_DEV=true`
+ * despite running with `NODE_ENV=production`.
+ */
+export const isDev = () => !isProd() || process.env.IS_DEV === 'true'
+
+/**
  * The base deployed domain (e.g. 'dev.sageleaf.app' or 'sageleaf.app')
  */
 export const getBaseDomain = () => process.env.BASE_DOMAIN ?? 'dev.sageleaf.app'
+
+/**
+ * CIDRs/IPs of proxies trusted to set `X-Forwarded-For`, used to resolve
+ * the real client IP for rate limiting. Comma-separated in `TRUSTED_PROXIES`.
+ */
+export const getTrustedProxies = () =>
+  process.env.TRUSTED_PROXIES?.split(',')
+    .map((proxy) => proxy.trim())
+    .filter(Boolean) ?? []


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add configurable trusted proxies for accurate client IP detection and update trusted origins to better handle dev and prod. This improves rate limiting accuracy and simplifies dev cluster setup.

- **New Features**
  - Support `advanced.ipAddress.trustedProxies` using `TRUSTED_PROXIES` (comma-separated CIDR/IP) via `getTrustedProxies()`.
  - Add `isDev()` to treat local and dev cluster (`IS_DEV=true`) as dev, even with `NODE_ENV=production`.
  - Refine `trustedOrigins`: include `https://${BASE_DOMAIN}` and `https://science.${BASE_DOMAIN}` in prod, localhost patterns in dev, and always allow Tauri origins.

<sup>Written for commit e9685912189549b014b1fcc42f1d201a78e56f95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

