### PR TITLE
api: Remove conflicting checks on tags

### DIFF
--- a/apps/api/src/db/migrations/.snapshot-sage.json
+++ b/apps/api/src/db/migrations/.snapshot-sage.json
@@ -2450,16 +2450,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "enumItems": [
-            "PLACE",
-            "ITEM",
-            "VARIANT",
-            "COMPONENT",
-            "PROCESS",
-            "PROGRAM",
-            "ORG"
-          ],
-          "mappedType": "enum"
+          "mappedType": "text"
         },
         "desc": {
           "name": "desc",

--- a/apps/api/src/db/migrations/Migration20260729055623.ts
+++ b/apps/api/src/db/migrations/Migration20260729055623.ts
@@ -1,0 +1,52 @@
+// this file was generated, do not edit unless creating a new migration
+
+import { Migration } from '@mikro-orm/migrations'
+
+export class Migration20260729055623 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`alter table "tags"
+                 drop constraint if exists "check_type";`)
+
+    this.addSql(`alter table "tags"
+                 drop constraint if exists "tags_type_check2";`)
+
+    this.addSql(`alter table "tags"
+                 drop constraint if exists "tags_type_check";`)
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "tags"
+                 add constraint "tags_type_check" check (
+                   "type" in (
+                     'PLACE',
+                     'ITEM',
+                     'VARIANT',
+                     'COMPONENT',
+                     'PROCESS',
+                     'PROGRAM',
+                     'ORG'
+                   )
+                 );`)
+
+    this.addSql(`alter table "tags"
+                 add constraint "tags_type_check2" check (
+                   "type" in (
+                     'PLACE',
+                     'ITEM',
+                     'VARIANT',
+                     'COMPONENT',
+                     'PROCESS',
+                     'ORG'
+                   )
+                 );`)
+
+    this.addSql(`alter table "tags"
+                 add constraint "check_type" check (
+                   "type" in (
+                     'PLACE',
+                     'VARIANT',
+                     'COMPONENT'
+                   )
+                 );`)
+  }
+}

--- a/apps/api/src/process/tag.entity.ts
+++ b/apps/api/src/process/tag.entity.ts
@@ -1,7 +1,6 @@
 import {
   Collection,
   Entity,
-  Enum,
   Index,
   ManyToMany,
   OptionalProps,
@@ -96,7 +95,7 @@ export class Tag extends IDCreatedUpdated {
   @Property({ type: 'json' })
   name!: TranslatedField
 
-  @Enum(() => TagType)
+  @Property({ type: 'text' })
   type!: TagType
 
   @Property({ type: 'json' })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed conflicting CHECK constraints on tag types and changed `Tag.type` from enum to text. This fixes failed inserts/updates caused by mismatched constraints and future-proofs tag type changes.

- **Bug Fixes**
  - Dropped legacy constraints: `check_type`, `tags_type_check`, `tags_type_check2` on the `tags` table.
  - Replaced `@Enum` with `@Property({ type: 'text' })` for `Tag.type`; migration snapshot now maps the column as text.

<sup>Written for commit dd7c75841b0034a22139f24dcca86dc79042e343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

