### PR TITLE
api: Add more m2m rel pagination options

### DIFF
--- a/apps/api/schema/schema.gql
+++ b/apps/api/schema/schema.gql
@@ -245,6 +245,9 @@ type Component implements Named {
   sources(after: String, before: String, first: Int, last: Int, type: String): ComponentSourcesConnection!
   tags(after: String, before: String, first: Int, last: Int): TagConnection!
   updatedAt: DateTime!
+
+  """Product variants that include this component"""
+  variants(after: String, before: String, first: Int, last: Int): VariantsConnection!
 }
 
 type ComponentEdge {
@@ -1190,6 +1193,15 @@ type Org implements Named {
   id: ID!
   name: String!
 
+  """Places belonging to this organization"""
+  places(after: String, before: String, first: Int, last: Int): PlacesConnection!
+
+  """Processes belonging to this organization"""
+  processes(after: String, before: String, first: Int, last: Int): ProcessConnection!
+
+  """Programs this organization participates in"""
+  programs(after: String, before: String, first: Int, last: Int): ProgramsConnection!
+
   """Similar organizations related to this organization"""
   related(limit: Int, offset: Int, query: String): OrgsConnection!
 
@@ -1199,6 +1211,9 @@ type Org implements Named {
 
   """Users that are members of this organization"""
   users(after: String, before: String, first: Int, last: Int): UserConnection!
+
+  """Product variants linked to this organization"""
+  variants(after: String, before: String, first: Int, last: Int): VariantsConnection!
 
   """URL of the organization's website"""
   websiteURL: String
@@ -1617,6 +1632,9 @@ enum RefModelType {
 type Region {
   """Bounding box as [minLon, minLat, maxLon, maxLat]"""
   bbox: [Float!]
+
+  """Components associated with this region"""
+  components(after: String, before: String, first: Int, last: Int): ComponentsConnection!
   country: Region
   county: Region
   createdAt: DateTime!
@@ -1629,9 +1647,18 @@ type Region {
 
   """The type of geographic entity (e.g. country, region, locality)"""
   placetype: String!
+
+  """Processes associated with this region"""
+  processes(after: String, before: String, first: Int, last: Int): ProcessConnection!
+
+  """Programs associated with this region"""
+  programs(after: String, before: String, first: Int, last: Int): ProgramsConnection!
   province: Region
   searchWithin(adminLevel: Int, limit: Int, offset: Int, query: String!): RegionsConnection!
   updatedAt: DateTime!
+
+  """Product variants associated with this region"""
+  variants(after: String, before: String, first: Int, last: Int): VariantsConnection!
 }
 
 type RegionEdge {
@@ -2475,6 +2502,9 @@ type Variant implements Named {
   Organizations associated with this variant (e.g. manufacturer, importer)
   """
   orgs(after: String, before: String, first: Int, last: Int): VariantOrgsConnection!
+
+  """Recycling or disposal processes specific to this variant"""
+  processes(after: String, before: String, first: Int, last: Int): ProcessConnection!
 
   """Recycling options for this variant, one entry per recycling stream"""
   recycle(regionID: ID): [VariantRecycle!]!

--- a/apps/api/src/geo/region.model.ts
+++ b/apps/api/src/geo/region.model.ts
@@ -5,6 +5,10 @@ import { z } from 'zod/v4'
 import { LuxonDateTimeResolver } from '@src/common/datetime.model'
 import { CreatedUpdated, registerModel } from '@src/graphql/base.model'
 import { Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { ComponentsConnection } from '@src/process/component.model'
+import { ProcessConnection } from '@src/process/process.model'
+import { ProgramsConnection } from '@src/process/program.model'
+import { VariantsConnection } from '@src/product/variant.model'
 
 @ObjectType({ description: "A geographic region based on the Who's On First dataset" })
 export class Region extends CreatedUpdated {
@@ -33,6 +37,18 @@ export class Region extends CreatedUpdated {
     description: 'Minimum map zoom level at which this region should be displayed',
   })
   minZoom?: number
+
+  @Field(() => ComponentsConnection, { description: 'Components associated with this region' })
+  components!: ComponentsConnection & {}
+
+  @Field(() => ProcessConnection, { description: 'Processes associated with this region' })
+  processes!: ProcessConnection & {}
+
+  @Field(() => ProgramsConnection, { description: 'Programs associated with this region' })
+  programs!: ProgramsConnection & {}
+
+  @Field(() => VariantsConnection, { description: 'Product variants associated with this region' })
+  variants!: VariantsConnection & {}
 }
 registerModel('Region', Region)
 
@@ -74,6 +90,26 @@ export class RegionSearchWithinArgs {
 
 @ArgsType()
 export class RegionsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class RegionComponentsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class RegionProcessesArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class RegionProgramsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class RegionVariantsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
 }
 

--- a/apps/api/src/geo/region.resolver.ts
+++ b/apps/api/src/geo/region.resolver.ts
@@ -9,12 +9,20 @@ import { Region as RegionEntity } from '@src/geo/region.entity'
 import {
   CurrentRegion,
   Region,
+  RegionComponentsArgs,
+  RegionProcessesArgs,
+  RegionProgramsArgs,
   RegionsArgs,
   RegionsConnection,
   RegionSearchWithinArgs,
   RegionsSearchByPointArgs,
+  RegionVariantsArgs,
 } from '@src/geo/region.model'
 import { RegionService } from '@src/geo/region.service'
+import { Component, ComponentsConnection } from '@src/process/component.model'
+import { Process, ProcessConnection } from '@src/process/process.model'
+import { Program, ProgramsConnection } from '@src/process/program.model'
+import { Variant, VariantsConnection } from '@src/product/variant.model'
 
 @Resolver(() => Region)
 export class RegionResolver {
@@ -132,6 +140,34 @@ export class RegionResolver {
       { items: models, count: cursor.count },
       true,
     )
+  }
+
+  @ResolveField()
+  async components(@Parent() region: Region, @Args() args: RegionComponentsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(RegionComponentsArgs, args)
+    const cursor = await this.regionService.components(region.id, filter)
+    return this.transform.entityToPaginated(Component, ComponentsConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async processes(@Parent() region: Region, @Args() args: RegionProcessesArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(RegionProcessesArgs, args)
+    const cursor = await this.regionService.processes(region.id, filter)
+    return this.transform.entityToPaginated(Process, ProcessConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async programs(@Parent() region: Region, @Args() args: RegionProgramsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(RegionProgramsArgs, args)
+    const cursor = await this.regionService.programs(region.id, filter)
+    return this.transform.entityToPaginated(Program, ProgramsConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async variants(@Parent() region: Region, @Args() args: RegionVariantsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(RegionVariantsArgs, args)
+    const cursor = await this.regionService.variants(region.id, filter)
+    return this.transform.entityToPaginated(Variant, VariantsConnection, cursor, parsedArgs)
   }
 
   @Query(() => RegionsConnection, { name: 'searchRegionsByPoint' })

--- a/apps/api/src/geo/region.service.ts
+++ b/apps/api/src/geo/region.service.ts
@@ -6,6 +6,10 @@ import { BadRequestErr } from '@src/common/exceptions'
 import { CursorOptions } from '@src/common/transform'
 import { IEntityService, IsEntityService, QueryField } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
+import { Component } from '@src/process/component.entity'
+import { Process } from '@src/process/process.entity'
+import { Program } from '@src/process/program.entity'
+import { Variant } from '@src/product/variant.entity'
 import { SearchIndex } from '@src/search/search.backend'
 import { SearchService } from '@src/search/search.service'
 
@@ -36,6 +40,34 @@ export class RegionService implements IEntityService<Region> {
 
   async findManyByID(ids: string[]) {
     return this.em.find(Region, { id: { $in: ids } })
+  }
+
+  async components(regionID: string, opts: CursorOptions<Component>) {
+    opts.where.region = regionID
+    const items = await this.em.find(Component, opts.where, opts.options)
+    const count = await this.em.count(Component, opts.where)
+    return { items, count }
+  }
+
+  async processes(regionID: string, opts: CursorOptions<Process>) {
+    opts.where.region = regionID
+    const items = await this.em.find(Process, opts.where, opts.options)
+    const count = await this.em.count(Process, opts.where)
+    return { items, count }
+  }
+
+  async programs(regionID: string, opts: CursorOptions<Program>) {
+    opts.where.region = regionID
+    const items = await this.em.find(Program, opts.where, opts.options)
+    const count = await this.em.count(Program, opts.where)
+    return { items, count }
+  }
+
+  async variants(regionID: string, opts: CursorOptions<Variant>) {
+    opts.where.region = regionID
+    const items = await this.em.find(Variant, opts.where, opts.options)
+    const count = await this.em.count(Variant, opts.where)
+    return { items, count }
   }
 
   async findMostSpecificByPoint(args: {

--- a/apps/api/src/process/component.model.ts
+++ b/apps/api/src/process/component.model.ts
@@ -29,6 +29,7 @@ import {
 } from '@src/process/stream.model'
 import { TagConnection } from '@src/process/tag.model'
 import { ImagesConnection } from '@src/product/image.model'
+import { VariantsConnection } from '@src/product/variant.model'
 import { User as UserEntity } from '@src/users/users.entity'
 import { User } from '@src/users/users.model'
 
@@ -115,6 +116,11 @@ export class Component extends IDCreatedUpdated implements Named {
   @Field(() => ImagesConnection, { description: 'Images associated with this component' })
   images!: ImagesConnection
 
+  @Field(() => VariantsConnection, {
+    description: 'Product variants that include this component',
+  })
+  variants!: VariantsConnection & {}
+
   @Field(() => ComponentsConnection, {
     description: 'Similar components related to this component',
   })
@@ -173,6 +179,11 @@ export class ComponentHistoryArgs extends PaginationBasicArgs {
 
 @ArgsType()
 export class ComponentTagsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class ComponentVariantsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
 }
 

--- a/apps/api/src/process/component.resolver.ts
+++ b/apps/api/src/process/component.resolver.ts
@@ -28,6 +28,7 @@ import {
   ComponentSourcesArgs,
   ComponentSourcesConnection,
   ComponentTagsArgs,
+  ComponentVariantsArgs,
   CreateComponentInput,
   CreateComponentOutput,
   UpdateComponentInput,
@@ -39,6 +40,7 @@ import { Material } from '@src/process/material.model'
 import { MaterialService } from '@src/process/material.service'
 import { Tag, TagConnection } from '@src/process/tag.model'
 import { Image, ImagesArgs, ImagesConnection } from '@src/product/image.model'
+import { Variant, VariantsConnection } from '@src/product/variant.model'
 import { RelatedArgs } from '@src/search/related.model'
 import { SearchIndex } from '@src/search/search.backend'
 import { SearchService } from '@src/search/search.service'
@@ -228,6 +230,13 @@ export class ComponentResolver {
     const [parsedArgs, filter] = await this.transform.paginationArgs(ImagesArgs, args)
     const cursor = await this.componentService.images(component.id, filter)
     return this.transform.entityToPaginated(Image, ImagesConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField(() => VariantsConnection)
+  async variants(@Parent() component: Component, @Args() args: ComponentVariantsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(ComponentVariantsArgs, args)
+    const cursor = await this.componentService.variants(component.id, filter)
+    return this.transform.entityToPaginated(Variant, VariantsConnection, cursor, parsedArgs)
   }
 
   @ResolveField(() => ComponentsConnection)

--- a/apps/api/src/process/component.service.ts
+++ b/apps/api/src/process/component.service.ts
@@ -23,6 +23,7 @@ import { Material } from '@src/process/material.entity'
 import { StreamService } from '@src/process/stream.service'
 import { Tag } from '@src/process/tag.entity'
 import { TagService } from '@src/process/tag.service'
+import { Variant } from '@src/product/variant.entity'
 
 @Injectable()
 @IsEntityService(Component)
@@ -240,6 +241,13 @@ export class ComponentService implements IEntityService<Component> {
       source: { type: SourceType.IMAGE },
     })
     return { items: componentSources.map((cs) => cs.source), count }
+  }
+
+  async variants(componentID: string, opts: CursorOptions<Variant>) {
+    opts.where.components = this.em.getReference(Component, componentID)
+    const items = await this.em.find(Variant, opts.where, opts.options)
+    const count = await this.em.count(Variant, { components: opts.where.components })
+    return { items, count }
   }
 
   async sources(componentID: string, opts: CursorOptions<ComponentsSources>) {

--- a/apps/api/src/process/process.model.ts
+++ b/apps/api/src/process/process.model.ts
@@ -89,13 +89,13 @@ export class Process extends IDCreatedUpdated implements Named {
     nullable: true,
     description: 'The geographic region where this process is available',
   })
-  region?: Region
+  region?: Region & {}
 
   @Field(() => Place, {
     nullable: true,
     description: 'The physical location where this process is carried out',
   })
-  place?: Place
+  place?: Place & {}
 
   @Field(() => ProcessSourcesConnection)
   sources!: ProcessSourcesConnection & {}

--- a/apps/api/src/process/stream.model.ts
+++ b/apps/api/src/process/stream.model.ts
@@ -267,13 +267,13 @@ export class ComponentReuse {
 @ObjectType({ description: 'A program associated with a recycling, reduce, or reuse stream' })
 export class StreamProgram {
   @Field(() => Program)
-  program!: Program
+  program!: Program & {}
 
   @Field(() => Org, { nullable: true })
-  org?: Org
+  org?: Org & {}
 
   @Field(() => Place, { nullable: true })
-  place?: Place
+  place?: Place & {}
 }
 
 @ObjectType()

--- a/apps/api/src/product/variant.entity.ts
+++ b/apps/api/src/product/variant.entity.ts
@@ -22,6 +22,7 @@ import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema
 import { IDCreatedUpdated } from '@src/db/base.entity'
 import { Region } from '@src/geo/region.entity'
 import { Component } from '@src/process/component.entity'
+import { Process } from '@src/process/process.entity'
 import { Tag } from '@src/process/tag.entity'
 import { Item } from '@src/product/item.entity'
 import { Org } from '@src/users/org.entity'
@@ -113,6 +114,9 @@ export class Variant extends IDCreatedUpdated {
     orphanRemoval: true,
   })
   variantComponents = new Collection<VariantsComponents>(this)
+
+  @OneToMany({ mappedBy: 'variant' })
+  processes = new Collection<Process>(this)
 
   @OneToMany(() => VariantHistory, (history) => history.variant)
   history = new Collection<VariantHistory>(this)

--- a/apps/api/src/product/variant.model.ts
+++ b/apps/api/src/product/variant.model.ts
@@ -21,6 +21,7 @@ import {
 import { Named } from '@src/graphql/interfaces.model'
 import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
 import { Component, ComponentsConnection } from '@src/process/component.model'
+import { ProcessConnection } from '@src/process/process.model'
 import {
   RecyclingStream,
   ReduceStream,
@@ -108,6 +109,11 @@ export class Variant extends IDCreatedUpdated implements Named {
 
   @Field(() => ItemsConnection, { description: 'Product items this variant belongs to' })
   items!: ItemsConnection
+
+  @Field(() => ProcessConnection, {
+    description: 'Recycling or disposal processes specific to this variant',
+  })
+  processes!: ProcessConnection & {}
 
   @Field(() => VariantsConnection, { description: 'Similar variants related to this variant' })
   related!: VariantsConnection & {}
@@ -302,6 +308,11 @@ export class VariantTagsArgs extends PaginationBasicArgs {
 
 @ArgsType()
 export class VariantItemsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class VariantProcessesArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
 }
 

--- a/apps/api/src/product/variant.resolver.ts
+++ b/apps/api/src/product/variant.resolver.ts
@@ -12,6 +12,7 @@ import { TransformService } from '@src/common/transform'
 import { Region, RegionsConnection } from '@src/geo/region.model'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
 import { Component, ComponentsConnection } from '@src/process/component.model'
+import { Process, ProcessConnection } from '@src/process/process.model'
 import { Tag, TagConnection } from '@src/process/tag.model'
 import { Image, ImagesArgs, ImagesConnection } from '@src/product/image.model'
 import { Item, ItemsConnection } from '@src/product/item.model'
@@ -32,6 +33,7 @@ import {
   VariantOrg,
   VariantOrgsArgs,
   VariantOrgsConnection,
+  VariantProcessesArgs,
   VariantRecycle,
   VariantRecycleArgs,
   VariantRecycleComponentsArgs,
@@ -106,6 +108,13 @@ export class VariantResolver {
     const [parsedArgs, filter] = await this.transform.paginationArgs(VariantItemsArgs, args)
     const cursor = await this.variantService.items(variant.id, filter)
     return this.transform.entityToPaginated(Item, ItemsConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async processes(@Parent() variant: Variant, @Args() args: VariantProcessesArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(VariantProcessesArgs, args)
+    const cursor = await this.variantService.processes(variant.id, filter)
+    return this.transform.entityToPaginated(Process, ProcessConnection, cursor, parsedArgs)
   }
 
   @ResolveField(() => VariantsConnection)

--- a/apps/api/src/product/variant.service.ts
+++ b/apps/api/src/product/variant.service.ts
@@ -98,6 +98,16 @@ export class VariantService implements IEntityService<Variant> {
     }
   }
 
+  async processes(variantID: string, opts: CursorOptions<Process>) {
+    opts.where.variant = variantID
+    const items = await this.em.find(Process, opts.where, opts.options)
+    const count = await this.em.count(Process, opts.where)
+    return {
+      items,
+      count,
+    }
+  }
+
   async orgs(variantID: string, opts: CursorOptions<VariantsOrgs>) {
     opts.where.variant = this.em.getReference(Variant, variantID)
     opts.options.populate = ['org']

--- a/apps/api/src/users/org.entity.ts
+++ b/apps/api/src/users/org.entity.ts
@@ -17,6 +17,7 @@ import { ExcludeFromDiff } from '@src/common/exclude-from-diff.decorator'
 import { defaultTranslatedField, type TranslatedField } from '@src/common/i18n'
 import { type JSONObject, type Rank, RANK_ORDER_SQL } from '@src/common/z.schema'
 import { IDCreatedUpdated } from '@src/db/base.entity'
+import { Place } from '@src/geo/place.entity'
 import { Process } from '@src/process/process.entity'
 import { Program } from '@src/process/program.entity'
 import { Variant } from '@src/product/variant.entity'
@@ -70,6 +71,9 @@ export class Org extends IDCreatedUpdated {
 
   @OneToMany({ mappedBy: 'org' })
   processes = new Collection<Process>(this)
+
+  @OneToMany({ mappedBy: 'org' })
+  places = new Collection<Place>(this)
 
   @ManyToMany({ entity: () => Program, mappedBy: 'orgs' })
   programs = new Collection<Program>(this)

--- a/apps/api/src/users/org.model.ts
+++ b/apps/api/src/users/org.model.ts
@@ -6,9 +6,13 @@ import { ChangeInputWithLang } from '@src/changes/change-ext.model'
 import { Change } from '@src/changes/change.model'
 import { LuxonDateTimeResolver } from '@src/common/datetime.model'
 import { IsNanoID } from '@src/common/validator.model'
+import { PlacesConnection } from '@src/geo/place.model'
 import { BaseModel, IDCreatedUpdated, type ModelRef, registerModel } from '@src/graphql/base.model'
 import { Named } from '@src/graphql/interfaces.model'
 import { OrderDirection, Paginated, PaginationBasicArgs } from '@src/graphql/paginated'
+import { ProcessConnection } from '@src/process/process.model'
+import { ProgramsConnection } from '@src/process/program.model'
+import { VariantsConnection } from '@src/product/variant.model'
 import { User as UserEntity } from '@src/users/users.entity'
 import { User, UserConnection } from '@src/users/users.model'
 
@@ -34,6 +38,18 @@ export class Org extends IDCreatedUpdated implements Named {
 
   @Field(() => UserConnection, { description: 'Users that are members of this organization' })
   users!: UserConnection & {}
+
+  @Field(() => PlacesConnection, { description: 'Places belonging to this organization' })
+  places!: PlacesConnection & {}
+
+  @Field(() => ProcessConnection, { description: 'Processes belonging to this organization' })
+  processes!: ProcessConnection & {}
+
+  @Field(() => ProgramsConnection, { description: 'Programs this organization participates in' })
+  programs!: ProgramsConnection & {}
+
+  @Field(() => VariantsConnection, { description: 'Product variants linked to this organization' })
+  variants!: VariantsConnection & {}
 
   @Field(() => OrgsConnection, {
     description: 'Similar organizations related to this organization',
@@ -89,6 +105,26 @@ export class OrgHistoryArgs extends PaginationBasicArgs {
 
 @ArgsType()
 export class OrgUsersArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class OrgPlacesArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class OrgProcessesArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class OrgProgramsArgs extends PaginationBasicArgs {
+  static schema = PaginationBasicArgs.schema
+}
+
+@ArgsType()
+export class OrgVariantsArgs extends PaginationBasicArgs {
   static schema = PaginationBasicArgs.schema
 }
 

--- a/apps/api/src/users/org.resolver.ts
+++ b/apps/api/src/users/org.resolver.ts
@@ -9,7 +9,11 @@ import { EditService } from '@src/changes/edit.service'
 import { TrackEntityView } from '@src/common/entity-view.decorator'
 import { NotFoundErr } from '@src/common/exceptions'
 import { TransformService } from '@src/common/transform'
+import { Place, PlacesConnection } from '@src/geo/place.model'
 import { DeleteOutput, ModelEditSchema } from '@src/graphql/base.model'
+import { Process, ProcessConnection } from '@src/process/process.model'
+import { Program, ProgramsConnection } from '@src/process/program.model'
+import { Variant, VariantsConnection } from '@src/product/variant.model'
 import { RelatedArgs } from '@src/search/related.model'
 import { SearchIndex } from '@src/search/search.backend'
 import { SearchService } from '@src/search/search.service'
@@ -21,9 +25,13 @@ import {
   OrgHistory,
   OrgHistoryArgs,
   OrgHistoryConnection,
+  OrgPlacesArgs,
+  OrgProcessesArgs,
+  OrgProgramsArgs,
   OrgsArgs,
   OrgsConnection,
   OrgUsersArgs,
+  OrgVariantsArgs,
   UpdateOrgInput,
   UpdateOrgOutput,
 } from '@src/users/org.model'
@@ -81,6 +89,34 @@ export class OrgResolver {
     const [parsedArgs, filter] = await this.transform.paginationArgs(OrgUsersArgs, args)
     const cursor = await this.orgService.users(org.id, filter)
     return this.transform.entityToPaginated(User, UserConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async places(@Parent() org: Org, @Args() args: OrgPlacesArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(OrgPlacesArgs, args)
+    const cursor = await this.orgService.places(org.id, filter)
+    return this.transform.entityToPaginated(Place, PlacesConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async processes(@Parent() org: Org, @Args() args: OrgProcessesArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(OrgProcessesArgs, args)
+    const cursor = await this.orgService.processes(org.id, filter)
+    return this.transform.entityToPaginated(Process, ProcessConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async programs(@Parent() org: Org, @Args() args: OrgProgramsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(OrgProgramsArgs, args)
+    const cursor = await this.orgService.programs(org.id, filter)
+    return this.transform.entityToPaginated(Program, ProgramsConnection, cursor, parsedArgs)
+  }
+
+  @ResolveField()
+  async variants(@Parent() org: Org, @Args() args: OrgVariantsArgs) {
+    const [parsedArgs, filter] = await this.transform.paginationArgs(OrgVariantsArgs, args)
+    const cursor = await this.orgService.variants(org.id, filter)
+    return this.transform.entityToPaginated(Variant, VariantsConnection, cursor, parsedArgs)
   }
 
   @ResolveField(() => OrgsConnection)

--- a/apps/api/src/users/org.service.ts
+++ b/apps/api/src/users/org.service.ts
@@ -8,6 +8,10 @@ import { ConflictErr, NotFoundErr } from '@src/common/exceptions'
 import { I18nService } from '@src/common/i18n.service'
 import { CursorOptions } from '@src/common/transform'
 import { IEntityService, IsEntityService, QueryField } from '@src/db/base.entity'
+import { Place } from '@src/geo/place.entity'
+import { Process } from '@src/process/process.entity'
+import { Program } from '@src/process/program.entity'
+import { Variant } from '@src/product/variant.entity'
 import { Org, OrgHistory } from '@src/users/org.entity'
 import { CreateOrgInput, UpdateOrgInput } from '@src/users/org.model'
 import { User } from '@src/users/users.entity'
@@ -47,6 +51,34 @@ export class OrgService implements IEntityService<Org> {
       items: users,
       count,
     }
+  }
+
+  async places(orgID: string, opts: CursorOptions<Place>) {
+    opts.where.org = orgID
+    const items = await this.em.find(Place, opts.where, opts.options)
+    const count = await this.em.count(Place, opts.where)
+    return { items, count }
+  }
+
+  async processes(orgID: string, opts: CursorOptions<Process>) {
+    opts.where.org = orgID
+    const items = await this.em.find(Process, opts.where, opts.options)
+    const count = await this.em.count(Process, opts.where)
+    return { items, count }
+  }
+
+  async programs(orgID: string, opts: CursorOptions<Program>) {
+    opts.where.orgs = this.em.getReference(Org, orgID)
+    const items = await this.em.find(Program, opts.where, opts.options)
+    const count = await this.em.count(Program, { orgs: opts.where.orgs })
+    return { items, count }
+  }
+
+  async variants(orgID: string, opts: CursorOptions<Variant>) {
+    opts.where.orgs = this.em.getReference(Org, orgID)
+    const items = await this.em.find(Variant, opts.where, opts.options)
+    const count = await this.em.count(Variant, { orgs: opts.where.orgs })
+    return { items, count }
   }
 
   async create(input: CreateOrgInput, userID: string) {

--- a/apps/api/test/gql/graphql.ts
+++ b/apps/api/test/gql/graphql.ts
@@ -331,6 +331,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -408,6 +410,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1740,6 +1751,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1747,6 +1764,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1754,6 +1773,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1771,6 +1817,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2500,6 +2555,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2510,9 +2567,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2522,6 +2612,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3332,6 +3431,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3393,6 +3494,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/apps/api/test/gql/types.generated.ts
+++ b/apps/api/test/gql/types.generated.ts
@@ -327,6 +327,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -404,6 +406,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1736,6 +1747,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1743,6 +1760,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1750,6 +1769,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1767,6 +1813,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2496,6 +2551,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2506,9 +2563,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2518,6 +2608,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3328,6 +3427,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3389,6 +3490,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/apps/frontend/app/gql/graphql.ts
+++ b/apps/frontend/app/gql/graphql.ts
@@ -331,6 +331,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -408,6 +410,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -884,6 +895,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1736,6 +1751,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1743,6 +1764,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1750,6 +1773,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1767,6 +1817,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2496,6 +2555,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2506,9 +2567,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2518,6 +2612,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3328,6 +3431,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3389,6 +3494,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/apps/frontend/app/gql/types.generated.ts
+++ b/apps/frontend/app/gql/types.generated.ts
@@ -327,6 +327,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -404,6 +406,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -880,6 +891,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1732,6 +1747,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1739,6 +1760,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1746,6 +1769,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1763,6 +1813,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2492,6 +2551,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2502,9 +2563,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2514,6 +2608,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3324,6 +3427,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3385,6 +3490,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/apps/science/app/gql/graphql.ts
+++ b/apps/science/app/gql/graphql.ts
@@ -331,6 +331,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -408,6 +410,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -884,6 +895,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1736,6 +1751,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1743,6 +1764,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1750,6 +1773,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1767,6 +1817,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2496,6 +2555,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2506,9 +2567,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2518,6 +2612,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3328,6 +3431,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3389,6 +3494,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/apps/science/app/gql/types.generated.ts
+++ b/apps/science/app/gql/types.generated.ts
@@ -327,6 +327,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -404,6 +406,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -880,6 +891,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1732,6 +1747,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1739,6 +1760,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1746,6 +1769,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1763,6 +1813,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2492,6 +2551,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2502,9 +2563,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2514,6 +2608,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3324,6 +3427,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3385,6 +3490,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/ui/app/gql/graphql.ts
+++ b/packages/ui/app/gql/graphql.ts
@@ -331,6 +331,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -408,6 +410,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -884,6 +895,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1736,6 +1751,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1743,6 +1764,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1750,6 +1773,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1767,6 +1817,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2496,6 +2555,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2506,9 +2567,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2518,6 +2612,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3328,6 +3431,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3389,6 +3494,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/ui/app/gql/types.generated.ts
+++ b/packages/ui/app/gql/types.generated.ts
@@ -327,6 +327,8 @@ export type Component = Named & {
   sources: ComponentSourcesConnection;
   tags: TagConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants that include this component */
+  variants: VariantsConnection;
 };
 
 
@@ -404,6 +406,15 @@ export type ComponentSourcesArgs = {
 
 /** A physical component of a product variant, made of one or more materials */
 export type ComponentTagsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A physical component of a product variant, made of one or more materials */
+export type ComponentVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -880,6 +891,10 @@ export type Edit = {
   changes?: Maybe<EditModel>;
   /** The raw JSON of the proposed entity changes */
   changesJSON?: Maybe<Scalars['JSONObject']['output']>;
+  /** True if a field this edit modifies has changed in the database since this edit was created */
+  conflict: Scalars['Boolean']['output'];
+  /** Description of the conflict, if any */
+  conflictDesc?: Maybe<Scalars['String']['output']>;
   /** Input values for creating a new entity, copying existing values */
   copyInput?: Maybe<Scalars['JSONObject']['output']>;
   /** Input values for creating a new entity */
@@ -1732,6 +1747,12 @@ export type Org = Named & {
   /** The ID of the model */
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Places belonging to this organization */
+  places: PlacesConnection;
+  /** Processes belonging to this organization */
+  processes: ProcessConnection;
+  /** Programs this organization participates in */
+  programs: ProgramsConnection;
   /** Similar organizations related to this organization */
   related: OrgsConnection;
   /** URL-friendly unique identifier for this organization */
@@ -1739,6 +1760,8 @@ export type Org = Named & {
   updatedAt: Scalars['DateTime']['output'];
   /** Users that are members of this organization */
   users: UserConnection;
+  /** Product variants linked to this organization */
+  variants: VariantsConnection;
   /** URL of the organization's website */
   websiteURL?: Maybe<Scalars['String']['output']>;
 };
@@ -1746,6 +1769,33 @@ export type Org = Named & {
 
 /** An organization or company on the platform */
 export type OrgHistoryArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgPlacesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgProgramsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -1763,6 +1813,15 @@ export type OrgRelatedArgs = {
 
 /** An organization or company on the platform */
 export type OrgUsersArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** An organization or company on the platform */
+export type OrgVariantsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2492,6 +2551,8 @@ export type Region = {
   __typename?: 'Region';
   /** Bounding box as [minLon, minLat, maxLon, maxLat] */
   bbox?: Maybe<Array<Scalars['Float']['output']>>;
+  /** Components associated with this region */
+  components: ComponentsConnection;
   country?: Maybe<Region>;
   county?: Maybe<Region>;
   createdAt: Scalars['DateTime']['output'];
@@ -2502,9 +2563,42 @@ export type Region = {
   name?: Maybe<Scalars['String']['output']>;
   /** The type of geographic entity (e.g. country, region, locality) */
   placetype: Scalars['String']['output'];
+  /** Processes associated with this region */
+  processes: ProcessConnection;
+  /** Programs associated with this region */
+  programs: ProgramsConnection;
   province?: Maybe<Region>;
   searchWithin: RegionsConnection;
   updatedAt: Scalars['DateTime']['output'];
+  /** Product variants associated with this region */
+  variants: VariantsConnection;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionComponentsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProcessesArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionProgramsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 
@@ -2514,6 +2608,15 @@ export type RegionSearchWithinArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   query: Scalars['String']['input'];
+};
+
+
+/** A geographic region based on the Who's On First dataset */
+export type RegionVariantsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
 };
 
 export type RegionEdge = {
@@ -3324,6 +3427,8 @@ export type Variant = Named & {
   name?: Maybe<Scalars['String']['output']>;
   /** Organizations associated with this variant (e.g. manufacturer, importer) */
   orgs: VariantOrgsConnection;
+  /** Recycling or disposal processes specific to this variant */
+  processes: ProcessConnection;
   /** Recycling options for this variant, one entry per recycling stream */
   recycle: Array<VariantRecycle>;
   /** Aggregated recyclability score for this variant */
@@ -3385,6 +3490,15 @@ export type VariantItemsArgs = {
 
 /** A specific variant or SKU of a product item, composed of physical components */
 export type VariantOrgsArgs = {
+  after?: InputMaybe<Scalars['String']['input']>;
+  before?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  last?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+/** A specific variant or SKU of a product item, composed of physical components */
+export type VariantProcessesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds cursor-paginated connections for more many-to-many relations in the GraphQL API to make related data easier to query. New fields on Component, Variant, Org, and Region include resolvers/service support, with regenerated client types.

- **New Features**
  - Component: `variants` connection
  - Variant: `processes` connection
  - Org: `places`, `processes`, `programs`, `variants` connections
  - Region: `components`, `processes`, `programs`, `variants` connections
  - Implemented pagination in resolvers/services and regenerated GraphQL types across `apps/api`, `apps/frontend`, `apps/science`, and `packages/ui`

<sup>Written for commit e855a034f2e52bbeb95b6e8f2e5d4c71cec4af6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sage-eco/sageleaf/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

